### PR TITLE
Data bug fix

### DIFF
--- a/mcstasscript/helper/managed_mcrun.py
+++ b/mcstasscript/helper/managed_mcrun.py
@@ -281,9 +281,10 @@ class ManagedMcrun:
             elif len(metadata.dimension) == 2:
                 xaxis = []  # Assume evenly binned in 2d
                 data_lines = metadata.dimension[1]
-                Intensity = data.T[:, 0:data_lines - 1]
-                Error = data.T[:, data_lines:2*data_lines - 1]
-                Ncount = data.T[:, 2*data_lines:3*data_lines - 1]
+
+                Intensity = data[0:data_lines, :]
+                Error = data[data_lines:2*data_lines, :]
+                Ncount = data[2*data_lines:3*data_lines, :]
             else:
                 raise NameError(
                     "Dimension not read correctly in data set "

--- a/mcstasscript/helper/managed_mcrun.py
+++ b/mcstasscript/helper/managed_mcrun.py
@@ -79,7 +79,7 @@ class ManagedMcrun:
 
         self.data_folder_name = ""
         self.ncount = int(1E6)
-        self.mpi = 1
+        self.mpi = None
         self.parameters = {}
         self.custom_flags = ""
         self.mcrun_path = ""
@@ -141,10 +141,14 @@ class ManagedMcrun:
         if self.compile:
             options_string = "-c "
 
+        if self.mpi is not None:
+            mpi_string = " --mpi=" + str(self.mpi) + " " # Set mpi
+        else:
+            mpi_string = " "
+
         option_string = (options_string
                          + "-n " + str(self.ncount)  # Set ncount
-                         + " --mpi=" + str(self.mpi)  # Set mpi
-                         + " ")
+                         + mpi_string)
 
         if self.increment_folder_name and os.path.isdir(self.data_folder_name):
             counter = 0

--- a/mcstasscript/interface/plotter.py
+++ b/mcstasscript/interface/plotter.py
@@ -139,10 +139,10 @@ class make_plot:
                                 data.metadata.dimension[0]+1)
                 Y = np.linspace(data.metadata.limits[2]*y_axis_mult,
                                 data.metadata.limits[3]*y_axis_mult,
-                                data.metadata.dimension[1])
+                                data.metadata.dimension[1]+1)
 
                 # Create a meshgrid for both x and y
-                y, x = np.meshgrid(Y, X)
+                x, y = np.meshgrid(X, Y)
 
                 # Generate information on necessary colorrange
                 levels = MaxNLocator(nbins=150).tick_values(min_value,
@@ -159,7 +159,7 @@ class make_plot:
                 if data.plot_options.log:
                     color_norm = matplotlib.colors.LogNorm(vmin=min_value,
                                                            vmax=max_value)
-                    im = ax0.pcolormesh(x, y, to_plot,
+                    im = ax0.pcolormesh(y, x, to_plot,
                                         cmap=cmap, norm=color_norm)
                 else:
                     im = ax0.pcolormesh(x, y, to_plot, cmap=cmap, norm=norm)
@@ -328,10 +328,10 @@ class make_sub_plot:
                                 data.metadata.dimension[0]+1)
                 Y = np.linspace(data.metadata.limits[2]*y_axis_mult,
                                 data.metadata.limits[3]*y_axis_mult,
-                                data.metadata.dimension[1])
+                                data.metadata.dimension[1]+1)
 
                 # Create a meshgrid for both x and y
-                y, x = np.meshgrid(Y, X)
+                x, y = np.meshgrid(X, Y)
 
                 # Generate information on necessary colorrange
                 levels = MaxNLocator(nbins=150).tick_values(min_value,
@@ -348,7 +348,7 @@ class make_sub_plot:
                     norm = BoundaryNorm(levels, ncolors=cmap.N, clip=True)
 
                 # Create plot
-                im = ax0.pcolormesh(x, y, to_plot, cmap=cmap, norm=norm)
+                im = ax0.pcolormesh(y, x, to_plot, cmap=cmap, norm=norm)
 
                 def fmt(x, pos):
                     a, b = '{:.2e}'.format(x).split('e')
@@ -551,10 +551,10 @@ class make_animation:
                             data.metadata.dimension[0]+1)
             Y = np.linspace(data.metadata.limits[2]*y_axis_mult,
                             data.metadata.limits[3]*y_axis_mult,
-                            data.metadata.dimension[1])
+                            data.metadata.dimension[1]+1)
 
             # Create a meshgrid for both x and y
-            y, x = np.meshgrid(Y, X)
+            x, y = np.meshgrid(X, Y)
 
             # Generate information on necessary colorrange
             levels = MaxNLocator(nbins=150).tick_values(min_value,
@@ -571,7 +571,7 @@ class make_animation:
                 norm = BoundaryNorm(levels, ncolors=cmap.N, clip=True)
 
             # Create plot
-            im = ax.pcolormesh(x, y, Intensity,
+            im = ax.pcolormesh(y, x, Intensity,
                                cmap=cmap, norm=norm)
 
             def fmt(x, pos):

--- a/mcstasscript/tests/test_Instr.py
+++ b/mcstasscript/tests/test_Instr.py
@@ -1511,7 +1511,7 @@ class TestMcStas_instr(unittest.TestCase):
         expected_folder_path = os.path.join(current_directory, "test_data_set")
 
         # a double space because of a missing option
-        expected_call = (expected_path + " -c -n 1000000 --mpi=1 "
+        expected_call = (expected_path + " -c -n 1000000 "
                          + "-d " + expected_folder_path
                          + "  test_instrument.instr"
                          + " has_default=37 theta=1")

--- a/mcstasscript/tests/test_ManagedMcrun.py
+++ b/mcstasscript/tests/test_ManagedMcrun.py
@@ -263,9 +263,9 @@ class TestManagedMcrun(unittest.TestCase):
         self.assertEqual(PSD_4PI.metadata.xlabel, "Longitude [deg]")
         self.assertEqual(PSD_4PI.metadata.ylabel, "Lattitude [deg]")
         self.assertEqual(PSD_4PI.metadata.title, "4PI PSD monitor")
-        self.assertEqual(PSD_4PI.Ncount[1][4], 4)
-        self.assertEqual(PSD_4PI.Intensity[1][4], 1.537334562E-10)
-        self.assertEqual(PSD_4PI.Error[1][4], 1.139482296E-10)
+        self.assertEqual(PSD_4PI.Ncount[4][1], 4)
+        self.assertEqual(PSD_4PI.Intensity[4][1], 1.537334562E-10)
+        self.assertEqual(PSD_4PI.Error[4][1], 1.139482296E-10)
 
     def test_ManagedMcrun_load_data_PSD(self):
         """
@@ -295,9 +295,9 @@ class TestManagedMcrun(unittest.TestCase):
         self.assertEqual(PSD.metadata.xlabel, "X position [cm]")
         self.assertEqual(PSD.metadata.ylabel, "Y position [cm]")
         self.assertEqual(PSD.metadata.title, "PSD monitor")
-        self.assertEqual(PSD.Ncount[21][27], 9)
-        self.assertEqual(PSD.Intensity[21][27], 2.623929371e-13)
-        self.assertEqual(PSD.Error[21][27], 2.765467693e-13)
+        self.assertEqual(PSD.Ncount[27][21], 9)
+        self.assertEqual(PSD.Intensity[27][21], 2.623929371e-13)
+        self.assertEqual(PSD.Error[27][21], 2.765467693e-13)
 
     def test_ManagedMcrun_load_data_L_mon(self):
         """

--- a/mcstasscript/tests/test_ManagedMcrun.py
+++ b/mcstasscript/tests/test_ManagedMcrun.py
@@ -38,7 +38,7 @@ class TestManagedMcrun(unittest.TestCase):
                                  foldername="test_folder",
                                  mcrun_path="")
 
-        self.assertEqual(mcrun_obj.mpi, 1)
+        self.assertEqual(mcrun_obj.mpi, None)
         self.assertEqual(mcrun_obj.ncount, 1000000)
         self.assertEqual(mcrun_obj.run_path, ".")
 
@@ -114,7 +114,7 @@ class TestManagedMcrun(unittest.TestCase):
         expected_folder_path = os.path.join(current_directory, "test_folder")
 
         # a double space because of a missing option
-        expected_call = ("path/mcrun -c -n 1000000 --mpi=1 "
+        expected_call = ("path/mcrun -c -n 1000000 "
                          + "-d " + expected_folder_path + "  test.instr")
 
         mock_sub.assert_called_once_with(expected_call,
@@ -138,7 +138,7 @@ class TestManagedMcrun(unittest.TestCase):
         expected_folder_path = os.path.join(current_directory, "test_folder")
 
         # a double space because of a missing option
-        expected_call = ("path/mcrun -c -n 1000000 --mpi=1 "
+        expected_call = ("path/mcrun -c -n 1000000 "
                          + "-d " + expected_folder_path + "  test.instr")
 
         mock_sub.assert_called_once_with(expected_call,

--- a/mcstasscript/tests/test_functions.py
+++ b/mcstasscript/tests/test_functions.py
@@ -256,9 +256,9 @@ class Test_load_data(unittest.TestCase):
         self.assertEqual(PSD_4PI.metadata.xlabel, "Longitude [deg]")
         self.assertEqual(PSD_4PI.metadata.ylabel, "Lattitude [deg]")
         self.assertEqual(PSD_4PI.metadata.title, "4PI PSD monitor")
-        self.assertEqual(PSD_4PI.Ncount[1][4], 4)
-        self.assertEqual(PSD_4PI.Intensity[1][4], 1.537334562E-10)
-        self.assertEqual(PSD_4PI.Error[1][4], 1.139482296E-10)
+        self.assertEqual(PSD_4PI.Ncount[4][1], 4)
+        self.assertEqual(PSD_4PI.Intensity[4][1], 1.537334562E-10)
+        self.assertEqual(PSD_4PI.Error[4][1], 1.139482296E-10)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
      name='McStasScript',
-     version='0.0.16',
+     version='0.0.18',
      author="Mads Bertelsen",
      author_email="Mads.Bertelsen@ess.eu",
      description="A python scripting interface for McStas",


### PR DESCRIPTION
Important bug fixed where not all data for 2D monitors were loaded, one row was missing.

Also updated storage of data to avoid storing a transposed matrix, now it is transposed in plotting.

Also includes the updates from disable_mpi so that no --mpi is given to mcrun when that option is not used, allowing users without functioning mpi installation to use the software.