### PR TITLE
Fix: do not change calling process' cwd

### DIFF
--- a/mcstasscript/helper/managed_mcrun.py
+++ b/mcstasscript/helper/managed_mcrun.py
@@ -186,17 +186,12 @@ class ManagedMcrun:
                   + parameter_string)
 
         try:
-            os.chdir(self.run_path)
-
             process = subprocess.run(full_command, shell=True,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
-                                     universal_newlines=True)
-
-            os.chdir(current_directory)
-
+                                     universal_newlines=True,
+                                     cwd=self.run_path)
         except:
-            os.chdir(current_directory)
             raise RuntimeError("Could not run McStas command.")
 
         if "suppress_output" in kwargs:

--- a/mcstasscript/tests/test_Instr.py
+++ b/mcstasscript/tests/test_Instr.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 import io
 import builtins
 import unittest
@@ -7,6 +8,9 @@ import datetime
 
 from mcstasscript.interface.instr import McStas_instr
 from mcstasscript.helper.formatting import bcolors
+
+
+run_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '.')
 
 
 def setup_instr_no_path():
@@ -1519,7 +1523,8 @@ class TestMcStas_instr(unittest.TestCase):
         mock_sub.assert_called_once_with(expected_call,
                                          shell=True,
                                          stderr=-1, stdout=-1,
-                                         universal_newlines=True)
+                                         universal_newlines=True,
+                                         cwd=run_path)
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     @unittest.mock.patch('__main__.__builtins__.open',
@@ -1558,7 +1563,8 @@ class TestMcStas_instr(unittest.TestCase):
         mock_sub.assert_called_once_with(expected_call,
                                          shell=True,
                                          stderr=-1, stdout=-1,
-                                         universal_newlines=True)
+                                         universal_newlines=True,
+                                         cwd=run_path)
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     @unittest.mock.patch('__main__.__builtins__.open',
@@ -1597,7 +1603,8 @@ class TestMcStas_instr(unittest.TestCase):
         mock_sub.assert_called_once_with(expected_call,
                                          shell=True,
                                          stderr=-1, stdout=-1,
-                                         universal_newlines=True)
+                                         universal_newlines=True,
+                                         cwd=run_path)
 
 
 if __name__ == '__main__':

--- a/mcstasscript/tests/test_ManagedMcrun.py
+++ b/mcstasscript/tests/test_ManagedMcrun.py
@@ -120,7 +120,8 @@ class TestManagedMcrun(unittest.TestCase):
         mock_sub.assert_called_once_with(expected_call,
                                          shell=True,
                                          stderr=-1, stdout=-1,
-                                         universal_newlines=True)
+                                         universal_newlines=True,
+                                         cwd=mcrun_obj.run_path)
 
     @unittest.mock.patch("subprocess.run")
     def test_ManagedMcrun_run_simulation_basic_path(self, mock_sub):
@@ -144,7 +145,8 @@ class TestManagedMcrun(unittest.TestCase):
         mock_sub.assert_called_once_with(expected_call,
                                          shell=True,
                                          stderr=-1, stdout=-1,
-                                         universal_newlines=True)
+                                         universal_newlines=True,
+                                         cwd=mcrun_obj.run_path)
 
     @unittest.mock.patch("subprocess.run")
     def test_ManagedMcrun_run_simulation_no_standard(self, mock_sub):
@@ -171,7 +173,8 @@ class TestManagedMcrun(unittest.TestCase):
         mock_sub.assert_called_once_with(expected_call,
                                          shell=True,
                                          stderr=-1, stdout=-1,
-                                         universal_newlines=True)
+                                         universal_newlines=True,
+                                         cwd=mcrun_obj.run_path)
 
     @unittest.mock.patch("subprocess.run")
     def test_ManagedMcrun_run_simulation_parameters(self, mock_sub):
@@ -201,7 +204,8 @@ class TestManagedMcrun(unittest.TestCase):
         mock_sub.assert_called_once_with(expected_call,
                                          shell=True,
                                          stderr=-1, stdout=-1,
-                                         universal_newlines=True)
+                                         universal_newlines=True,
+                                         cwd=mcrun_obj.run_path)
 
     @unittest.mock.patch("subprocess.run")
     def test_ManagedMcrun_run_simulation_compile(self, mock_sub):
@@ -233,7 +237,8 @@ class TestManagedMcrun(unittest.TestCase):
         mock_sub.assert_called_once_with(expected_call,
                                          shell=True,
                                          stderr=-1, stdout=-1,
-                                         universal_newlines=True)
+                                         universal_newlines=True,
+                                         cwd=mcrun_obj.run_path)
 
     def test_ManagedMcrun_load_data_PSD4PI(self):
         """


### PR DESCRIPTION
Changing calling process' current working directory (cwd) may lead to
unwanted side-effects. Better change the cwd on the subprocess.