### PR TITLE
Mcstas objects review

### DIFF
--- a/mcstasscript/helper/component_reader.py
+++ b/mcstasscript/helper/component_reader.py
@@ -19,15 +19,15 @@ class ComponentInfo:
 
 class ComponentReader:
     """
-    Class for retriveing information on available McStas components
+    Class for retrieving information on available McStas components
 
     Recursively reads all component files in hardcoded list of
     folders that represents the component categories in McStas.
     The results are stored in a dictionary with ComponentInfo
     instances, the keys are the names of the components. After
     the components in the McStas installation are read, any
-    components pressent in the current work directory is read,
-    and these will overwrite exisiting information, consistent
+    components present in the current work directory is read,
+    and these will overwrite existing information, consistent
     with how McStas reads component definitions.
 
     """
@@ -48,10 +48,6 @@ class ComponentReader:
 
         """
 
-        # add trailing / or \ depending on operating system
-        if mcstas_path[-1] is not "/" and mcstas_path[-1] is not "\\":
-            mcstas_path = os.path.join(mcstas_path, "") 
-
         # Hardcoded whitelist of foldernames
         folder_list = ["sources",
                        "optics",
@@ -67,6 +63,7 @@ class ComponentReader:
 
         for folder in folder_list:
             abs_path = os.path.join(mcstas_path, folder)
+            abs_path = os.path.abspath(abs_path)
             self._find_components(abs_path)
 
         # Will overwrite McStas components with definitions in input_folder
@@ -86,15 +83,16 @@ class ComponentReader:
             print("input_path: ", input_directory)
             raise ValueError("Can't find given input_path,"
                              + " directory must exist.")
-
+        """
+        If components are present both in the McStas install and the 
+        work directory, the version in the work directory is used. The user
+        is informed of this behavior when the instrument object is created.
+        """
         overwritten_components = []
         for file in os.listdir(input_directory):
             if file.endswith(".comp"):
                 abs_path = os.path.join(input_directory, file)
-                if "/" in abs_path:
-                    component_name = abs_path.split("/")[-1].split(".")[-2]
-                else:
-                    component_name = abs_path.split("\\")[-1].split(".")[-2]
+                component_name = os.path.split(abs_path)[1].split(".")[-2]
 
                 if component_name in self.component_path:
                     overwritten_components.append(file)
@@ -102,6 +100,7 @@ class ComponentReader:
                 self.component_path[component_name] = abs_path
                 self.component_category[component_name] = "Work directory"
 
+        # Report components found in the work directory and install to the user
         if len(overwritten_components) > 0:
             print("The following components are found in the work_directory"
                   + " / input_path:")
@@ -129,7 +128,10 @@ class ComponentReader:
 
         """
         if "line_length" in kwargs:
-            line_limit = kwargs["line_length"]
+            line_limit = int(kwargs["line_length"])
+            if line_limit < 20:
+                raise ValueError("line_length should be more than 20 "
+                                 + "characters, was " + str(line_limit))
         else:
             line_limit = 100
 
@@ -150,7 +152,7 @@ class ComponentReader:
             for component in to_print:
                 print(" " + component)
         else:
-            # Prints in collumns, maximum 4 and maximum line length line_liimt
+            # Prints in columns, maximum 4 and maximum line length line_limit
             columns = 5
             total_line_length = 1000
             while(total_line_length > line_limit):
@@ -171,9 +173,9 @@ class ComponentReader:
 
                 total_line_length = 1 + sum(longest_name) + (columns-1)*3
 
-            for line_nr in range(0, c_length):
+            for line_nr in range(c_length):
                 print(" ", end="")
-                for col in range(0, columns-1):
+                for col in range(columns-1):
                     this_name = column[col][line_nr]
                     print(this_name
                           + " "*(longest_name[col] - len(this_name))
@@ -228,6 +230,9 @@ class ComponentReader:
 
         """
 
+        if not os.path.isabs(absolute_path):
+            raise RuntimeError("_find_components received non absolute path")
+
         if not os.path.isdir(absolute_path):
             if absolute_path.endswith(".comp"):
                 # read this file
@@ -252,20 +257,20 @@ class ComponentReader:
 
         result = ComponentInfo()
 
-        fo = open(absolute_path, "r")
+        file_o = open(absolute_path, "r")
 
-        cnt = 0
+        line_number = 0
         while True:
-            cnt += 1
-            line = fo.readline()
+            line_number += 1
+            line = file_o.readline()
 
             # find parameter comments
-            if self.line_starts_with(line, "* %P"):
+            if line.startswith("* %P"):
 
                 while True:
-                    this_line = fo.readline()
+                    this_line = file_o.readline()
 
-                    if self.line_starts_with(this_line, "DEFINE COMPONENT"):
+                    if this_line.startswith("DEFINE COMPONENT"):
                         # No more comments to read through
                         break
 
@@ -308,9 +313,9 @@ class ComponentReader:
                         result.parameter_comments[variable_name] = comment
 
             # find definition parameters and their values
-            if (self.line_starts_with(line.strip(), "DEFINITION PARAMETERS")
-                    or self.line_starts_with(line.strip(),
-                                             "SETTING PARAMETERS")):
+            if (line.strip().startswith("DEFINITION PARAMETERS")
+                    or line.strip().startswith("SETTING PARAMETERS")):
+
 
                 line = line.split("//")[0] # Remove comments
                 parts = line.split("(")
@@ -350,16 +355,16 @@ class ComponentReader:
                         if part == "":
                             continue
 
-                        if self.line_starts_with(part, "//"):
+                        if part.startswith("//"):
                             break_now = True
                             continue
 
-                        if self.line_starts_with(part, "/*"):
+                        if part.startswith("/*"):
                             break_now = True
                             continue
 
                         if "=" not in part:
-                            # no defualt value, required parameter
+                            # no default value, required parameter
                             result.parameter_names.append(part)
                             result.parameter_defaults[part] = None
                             result.parameter_types[part] = temp_par_type
@@ -373,8 +378,8 @@ class ComponentReader:
                                 try:
                                     par_value = float(par_value)
                                 except:
-                                    par_value = par_value
                                     # Could change the type
+                                    par_value = par_value
                             elif temp_par_type is "int":
                                 par_value = int(par_value)
 
@@ -385,26 +390,25 @@ class ComponentReader:
                     if break_now:
                         break
 
-                    new_line = fo.readline().split("//")[0]
+                    new_line = file_o.readline().split("//")[0]
                     parameter_parts = new_line.split(",")
                     parameter_parts = self.correct_for_brackets(parameter_parts)
 
-            if self.line_starts_with(line, "DECLARE"):
+            if line.startswith("DECLARE"):
                 break
 
-            if self.line_starts_with(line, "TRACE"):
+            if line.startswith("TRACE"):
                 break
 
-            if cnt == 1000:
+            if line_number == 4000:
                 break
 
-        fo.close()
+        file_o.close()
 
         result.name = os.path.split(absolute_path)[1].split(".")[-2]
         
         tail = os.path.split(absolute_path)[0]
         result.category = os.path.split(tail)[1]
-
 
         """
         To lower memory use one could remove all comments and units that
@@ -414,15 +418,24 @@ class ComponentReader:
         return result
     
     def correct_for_brackets(self, parameter_parts):
+        """
+        Given list of string elements, correct for brackets will
+        combine terms until curly brackets are balanced, for example:
+
+        ["A", "{B", "C", "D}", "E"] would return ["A", "{B,C,D}", "E"]
+
+        Default values of vectors can be given in such a manner in
+        McStas components, and without this each part would be recognized
+        as different parameters.
+        """
         corrected_parts = []
-        current_part = ""
         index = 0
         while True:
             
             current_part = parameter_parts[index]
             inner_index = 0
             while True: 
-                if (current_part.count("{") == current_part.count("}")):
+                if current_part.count("{") == current_part.count("}"):
                     corrected_parts.append(current_part)
                     index += inner_index
                     break                          
@@ -436,17 +449,4 @@ class ComponentReader:
                 break
             
         return corrected_parts
-        
 
-    def line_starts_with(self, line, string):
-        """
-        Helper method that checks if a string is the start of a line
-
-        """
-        if len(line) < len(string):
-            return False
-
-        if line[0:len(string)] == string:
-            return True
-        else:
-            return False

--- a/mcstasscript/helper/mcstas_objects.py
+++ b/mcstasscript/helper/mcstas_objects.py
@@ -65,7 +65,6 @@ class ParameterVariable:
             comment : str
                 sets comment displayed next to declaration
 
-
         """
         if len(args) == 1:
             self.type = ""
@@ -79,7 +78,6 @@ class ParameterVariable:
                                    + "\" which is not among the allowed types "
                                    + str(allowed_types) + ".")
 
-            #self.type = specified_type + " "
             self.type = specified_type
             self.name = str(args[1])
 

--- a/mcstasscript/helper/mcstas_objects.py
+++ b/mcstasscript/helper/mcstas_objects.py
@@ -4,7 +4,7 @@ from mcstasscript.helper.formatting import is_legal_parameter
 
 class parameter_variable:
     """
-    Class describing a input parameter in McStas instrument
+    Class describing an input parameter in McStas instrument
 
     McStas input parameters are of default type double, but can be
     cast.  If two positional arguments are given, the first is the
@@ -35,6 +35,18 @@ class parameter_variable:
     def __init__(self, *args, **kwargs):
         """Initializing mcstas parameter object
 
+        Examples
+        --------
+
+        Creates a parameter with name wavelength and associated comment
+        A = parameter_variable("wavelength", comment="wavelength in [AA]")
+
+        Creates a parameter with name A3 and default value
+        A = parameter_variable("A3", value=30, comment="A3 angle in [deg]")
+
+        Creates a parameter with type string and name sample_name
+        A = parameter_variable("string", "sample_name")
+
         Parameters
         ----------
         If giving a type:
@@ -52,12 +64,23 @@ class parameter_variable:
                 sets default value of parameter
             comment : str
                 sets comment displayed next to declaration
+
+
         """
         if len(args) == 1:
             self.type = ""
             self.name = str(args[0])
         if len(args) == 2:
-            self.type = args[0] + " "
+            specified_type = args[0]
+            allowed_types = {"double", "int", "string"}
+            if specified_type not in allowed_types:
+                raise RuntimeError("Tried to create parameter of type \""
+                                   + str(specified_type)
+                                   + "\" which is not among the allowed types "
+                                   + str(allowed_types) + ".")
+
+            #self.type = specified_type + " "
+            self.type = specified_type
             self.name = str(args[1])
 
         if not is_legal_parameter(self.name):
@@ -68,18 +91,27 @@ class parameter_variable:
 
         self.value = ""
         if "value" in kwargs:
+            if not isinstance(kwargs["value"], (str, int, float)):
+                raise RuntimeError("Given value for parameter has to be of"
+                                   + "type str, int or float.")
             self.value = kwargs["value"]
 
         self.comment = ""
         if "comment" in kwargs:
-            self.comment = "// " + kwargs["comment"]
-
-        # could check for allowed types
-        # they are int, double, string, are there more?
+            self.comment = kwargs["comment"]
+            if not isinstance(self.comment, str):
+                raise RuntimeError("Tried to create a parameter with a "
+                                   + "comment that was not a string.")
+            self.comment = "// " + self.comment
 
     def write_parameter(self, fo, stop_character):
         """Writes input parameter to file"""
-        fo.write("%s%s" % (self.type, self.name))
+
+        if not isinstance(stop_character, str):
+            raise RuntimeError("stop_character in write_parameter should be "
+                               + "a string.")
+
+        fo.write("%s %s" % (self.type, self.name))
         if self.value != "":
             if isinstance(self.value, int):
                 fo.write(" = %d" % self.value)
@@ -123,16 +155,29 @@ class declare_variable:
     write_line(fo)
         Writes a line to text file fo declaring the parameter in c
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, type, name, **kwargs):
         """
         Initializing mcstas parameter object
 
+        Examples
+        --------
+
+        Creates a variable with name A3 and default value
+        A = declare_variable("double", "A3", value=30)
+
+        Creates a variable with type integer and name sample_number
+        A = declare_variable("int", "sample_number")
+
+        Creates an array variable called m_values
+        A = declare_variable("double", "m_values", array=3,
+                             value=[2, 2.5, 2])
+
         Parameters
         ----------
-        Positional argument 1: type : str
+        type : str
             Type of the parameter, double, int or string
 
-        Positional argument 2: name : str
+        name : str
             Name of input parameter
 
         Keyword arguments
@@ -146,9 +191,13 @@ class declare_variable:
             comment : str
                 sets comment displayed next to declaration
         """
-        self.type = args[0]
-        self.name = str(args[1])
 
+        self.type = type
+        if not isinstance(self.type, str):
+            raise RuntimeError("Given type of declare_variable should be a "
+                               + "string.")
+
+        self.name = str(name)
 
         par_name = self.name
         if "*" in par_name[0]:
@@ -219,13 +268,13 @@ class declare_variable:
 
 class component:
     """
-    A class describing a McStas component to be written to a instrument
+    A class describing a McStas component to be written to an instrument
 
     This class is used by the instrument class when setting up
     components as dynamic subclasses to this class.  Most information
     can be given on initialize using keyword arguments, but there are
     methods for setting the attributes describing the component. The
-    class contains both methods to write the component to a instrument
+    class contains both methods to write the component to an instrument
     file and methods for printing to the python terminal for checking
     the information. The McStas_Instr class creates subclasses from
     this class that have attributes for all parameters for the given
@@ -243,34 +292,43 @@ class component:
     component_name : str
         Name of the component code to use, e.g. Arm, Guide_gravity, ...
 
-    AT_data : list of 3 floats
+    AT_data : list of 3 floats, default [0, 0, 0]
         Position data of the component
 
-    AT_relative : str
+    AT_relative : str, default "ABSOLUTE"
         Name of former component to use as reference for position
 
-    ROTATED_data : list of 3 floats
+    ROTATED_data : list of 3 floats, default [0, 0, 0]
         Rotation data of the component
 
-    ROTATED_relative : str
+    ROTATED_relative : str, default "ABSOLUTE"
         Name of former component to use as reference for position
 
-    WHEN : str
+    WHEN : str, default ""
         String with logical c expression x for when component is active
 
-    EXTEND : str
+    EXTEND : str, default ""
         c code for McStas EXTEND section
 
-    GROUP : str
+    GROUP : str, default ""
         Name of group the component should belong to
 
-    JUMP : str
+    JUMP : str, default ""
         String describing use of JUMP, need to contain all after "JUMP"
+
+    SPLIT : int, default 0 (disabled)
+        Integer setting SPLIT, splitting the neutron before this component
+
+    c_code_before : str, default ""
+        C code inserted before the component
+
+    c_code_after : str, default ""
+        C code inserted after the component
 
     component_parameters : dict
         Parameters to be used with component in dictionary
 
-    comment : str
+    comment : str, default ""
         Comment inserted before the component as an explanation
 
     __isfrozen : bool
@@ -299,6 +357,9 @@ class component:
     set_WHEN(string)
         Sets WHEN string
 
+    set_SPLIT(value)
+        Sets SPLIT value, a value of 0 disables SPLIT
+
     set_GROUP(string)
         Sets GROUP name
 
@@ -308,17 +369,32 @@ class component:
     append_EXTEND(string)
         Append string to EXTEND string
 
+    set_c_code_before(string)
+        Sets c code to be inserted before component
+
+    set_c_code_before(string)
+        Sets c code to be inserted after component
+
     set_comment(string)
         Sets comment for component
 
     write_component(fo)
         Writes component code to instrument file
 
+    show_parameters()
+        Prints current component state with all parameters
+
     print_long()
         Prints basic view of component code (not correct syntax)
 
+    print_long_deprecated()
+        Prints basic view of component code (obsolete)
+
     print_short(**kwargs)
         Prints short description, used in print_components
+
+    set_keyword_input(**kwargs)
+        Handle keyword arguments during initialize
 
     __setattr__(key, value)
         Overwriting __setattr__ to implement ability to freeze
@@ -345,37 +421,37 @@ class component:
             name of the component type e.g. Arm, Guide_gravity, ...
 
         keyword arguments:
-            AT : list of 3 floats
+            AT : list of 3 floats, default [0, 0, 0]
                 Sets AT_data describing position of component
 
-            AT_RELATIVE : str
+            AT_RELATIVE : str, default "ABSOLUTE"
                 sets AT_relative, describing position reference
 
-            ROTATED : list of 3 floats
+            ROTATED : list of 3 floats, default [0, 0, 0]
                 Sets ROTATED_data, describing rotation of component
 
-            ROTATED_RELATIVE : str
+            ROTATED_RELATIVE : str, default "ABSOLUTE"
                 Sets ROTATED_relative, sets reference for rotation
 
             RELATIVE : str
                 Sets both AT_relative and ROTATED_relative
 
-            WHEN : str
+            WHEN : str, default ""
                 Sets WHEN string, should contain logical c expression
 
-            EXTEND : str
+            EXTEND : str, default ""
                 Sets initial EXTEND string, should contain c code
 
-            GROUP : str
+            GROUP : str, default ""
                 Sets name of group the component should belong to
 
-            JUMP : str
+            JUMP : str, default ""
                 Sets JUMP str
                 
-            SPLIT : int
+            SPLIT : int, default 0 (disabled)
                 Sets SPLIT value
 
-            comment: str
+            comment: str, default ""
                 Sets comment string
         """
 
@@ -405,7 +481,7 @@ class component:
 
         """
         Could store an option for whether this component should be
-        printed in instrument file or in a seperate file which would
+        printed in instrument file or in a separate file which would
         then be included.
         """
 
@@ -433,29 +509,28 @@ class component:
             self.set_RELATIVE(kwargs["RELATIVE"])
 
         if "WHEN" in kwargs:
-            self.WHEN = "WHEN (" + kwargs["WHEN"] + ")"
+            self.set_WHEN(kwargs["WHEN"])
 
         if "EXTEND" in kwargs:
-            self.EXTEND = kwargs["EXTEND"] + "\n"
+            self.append_EXTEND(kwargs["EXTEND"])
 
         if "GROUP" in kwargs:
-            self.GROUP = kwargs["GROUP"]
+            self.set_GROUP(kwargs["GROUP"])
 
         if "JUMP" in kwargs:
-            self.JUMP = kwargs["JUMP"]
+            self.set_JUMP(kwargs["JUMP"])
             
         if "SPLIT" in kwargs:
-            self.SPLIT = kwargs["SPLIT"]
+            self.set_SPLIT(kwargs["SPLIT"])
 
         if "comment" in kwargs:
-            self.comment = kwargs["comment"]
+            self.set_comment(kwargs["comment"])
             
         if "c_code_before" in kwargs:
-            self.c_code_before = kwargs["c_code_before"]
+            self.set_c_code_before(kwargs["c_code_before"])
         
         if "c_code_after" in kwargs:
-            self.c_code_after = kwargs["c_code_after"]
-        
+            self.set_c_code_after(kwargs["c_code_after"])
 
     def __setattr__(self, key, value):
         if self.__isfrozen and not hasattr(self, key):
@@ -475,7 +550,19 @@ class component:
         self.__isfrozen = False
 
     def set_AT(self, at_list, RELATIVE=None):
-        """Sets AT data, List of 3 floats"""
+        """Sets AT data, List of 3 floats or single float for z only"""
+        if isinstance(at_list, (int, float)):
+            at_list = [0, 0, at_list]
+
+        if not isinstance(at_list, list):
+            raise RuntimeError("set_AT should be given either a list or "
+                               + "float, but received "
+                               + str(type(at_list)))
+
+        if len(at_list) != 3:
+            raise RuntimeError("Position data given to set_AT should "
+                               + "either be of length 3 or just a float.")
+
         self.AT_data = at_list
         if RELATIVE is not None:
             self.set_AT_RELATIVE(RELATIVE)
@@ -498,6 +585,15 @@ class component:
 
     def set_ROTATED(self, rotated_list, RELATIVE=None):
         """Sets ROTATED data, List of 3 floats"""
+        if not isinstance(rotated_list, list):
+            raise RuntimeError("set_ROTATED should be given a list "
+                               + " but received "
+                               + str(type(rotated_list)))
+
+        if len(rotated_list) != 3:
+            raise RuntimeError("Rotation data given to set_ROTATED should "
+                               + "be of length 3.")
+
         self.ROTATED_data = rotated_list
         self.ROTATED_specified = True
         if RELATIVE is not None:
@@ -538,12 +634,13 @@ class component:
 
     def set_parameters(self, dict_input):
         """
-        Adds parameters and their values from dictionary input
+        Set component parameters from dictionary input
 
-        Relies on attributes added when McStas_Instr creates a
-        subclass from the component class where each component
-        parameter is added as an attribute.
+        Relies on attributes added when McStas_Instr creates a subclass from
+        the component class where each component parameter is added as an
+        attribute.
 
+        An error is raised if trying to set a parameter that does not exist
         """
         for key, val in dict_input.items():
             if not hasattr(self, key):
@@ -559,34 +656,64 @@ class component:
 
     def set_WHEN(self, string):
         """Sets WHEN string, should be a c logical expression"""
+        if not isinstance(string, str):
+            raise RuntimeError("set_WHEN expect a string, but was "
+                               + "given " + str(type(string)))
         self.WHEN = "WHEN (" + string + ")"
 
     def set_GROUP(self, string):
         """Sets GROUP name"""
+        if not isinstance(string, str):
+            raise RuntimeError("set_GROUP expect a string, but was "
+                               + "given " + str(type(string)))
         self.GROUP = string
 
     def set_JUMP(self, string):
         """Sets JUMP string, should contain all text after JUMP"""
+        if not isinstance(string, str):
+            raise RuntimeError("set_JUMP expect a string, but was "
+                               + "given " + str(type(string)))
         self.JUMP = string
         
     def set_SPLIT(self, value):
-        """Sets SPLIT value, should contain all text after JUMP"""
+        """Sets SPLIT value, needs to be an integer"""
+        if not isinstance(value, (int, str)):
+            raise RuntimeError("set_SPLIT expect a integer or string, but "
+                               + "was given " + str(type(value)))
+
+        if isinstance(value, int):
+            if value < 0:
+                raise RuntimeError("set_SPLIT got a negative value, this is "
+                                   + "meaningless, has to be a positive value.")
+
         self.SPLIT = value
 
     def append_EXTEND(self, string):
         """Appends a line of code to EXTEND block of component"""
+        if not isinstance(string, str):
+            raise RuntimeError("append_EXTEND expect a string, but was "
+                               + "given " + str(type(string)))
         self.EXTEND = self.EXTEND + string + "\n"
 
     def set_comment(self, string):
         """Method that sets a comment to be written to instrument file"""
+        if not isinstance(string, str):
+            raise RuntimeError("set_comment expect a string, but was "
+                               + "given " + str(type(string)))
         self.comment = string
         
     def set_c_code_before(self, string):
         """Method that sets c code to be written before the component"""
+        if not isinstance(string, str):
+            raise RuntimeError("set_c_code_before expect a string, but was "
+                               + "given " + str(type(string)))
         self.c_code_before = string
         
     def set_c_code_after(self, string):
         """Method that sets c code to be written after the component"""
+        if not isinstance(string, str):
+            raise RuntimeError("set_c_code_after expect a string, but was "
+                               + "given " + str(type(string)))
         self.c_code_after = string
 
     def write_component(self, fo):
@@ -600,7 +727,6 @@ class component:
         parameters_per_line = 2
         # Could use character limit on lines instead
         parameters_written = 0  # internal parameter
-
 
         if len(self.c_code_before) > 0:
             explanation = "From component named " + self.name
@@ -689,7 +815,7 @@ class component:
         # Leave a new line between components for readability
         fo.write("\n")
 
-    def print_long_depricated(self):
+    def print_long_deprecated(self):
         """
         Prints contained information to Python terminal
 

--- a/mcstasscript/helper/mcstas_objects.py
+++ b/mcstasscript/helper/mcstas_objects.py
@@ -2,7 +2,7 @@ from mcstasscript.helper.formatting import bcolors
 from mcstasscript.helper.formatting import is_legal_parameter
 
 
-class parameter_variable:
+class ParameterVariable:
     """
     Class describing an input parameter in McStas instrument
 
@@ -39,13 +39,13 @@ class parameter_variable:
         --------
 
         Creates a parameter with name wavelength and associated comment
-        A = parameter_variable("wavelength", comment="wavelength in [AA]")
+        A = ParameterVariable("wavelength", comment="wavelength in [AA]")
 
         Creates a parameter with name A3 and default value
-        A = parameter_variable("A3", value=30, comment="A3 angle in [deg]")
+        A = ParameterVariable("A3", value=30, comment="A3 angle in [deg]")
 
         Creates a parameter with type string and name sample_name
-        A = parameter_variable("string", "sample_name")
+        A = ParameterVariable("string", "sample_name")
 
         Parameters
         ----------
@@ -124,7 +124,7 @@ class parameter_variable:
         fo.write("\n")
 
 
-class declare_variable:
+class DeclareVariable:
     """
     Class describing a declared variable in McStas instrument
 
@@ -163,13 +163,13 @@ class declare_variable:
         --------
 
         Creates a variable with name A3 and default value
-        A = declare_variable("double", "A3", value=30)
+        A = DeclareVariable("double", "A3", value=30)
 
         Creates a variable with type integer and name sample_number
-        A = declare_variable("int", "sample_number")
+        A = DeclareVariable("int", "sample_number")
 
         Creates an array variable called m_values
-        A = declare_variable("double", "m_values", array=3,
+        A = DeclareVariable("double", "m_values", array=3,
                              value=[2, 2.5, 2])
 
         Parameters
@@ -194,7 +194,7 @@ class declare_variable:
 
         self.type = type
         if not isinstance(self.type, str):
-            raise RuntimeError("Given type of declare_variable should be a "
+            raise RuntimeError("Given type of DeclareVariable should be a "
                                + "string.")
 
         self.name = str(name)
@@ -266,7 +266,7 @@ class declare_variable:
                 
 
 
-class component:
+class Component:
     """
     A class describing a McStas component to be written to an instrument
 
@@ -570,12 +570,12 @@ class component:
     def set_AT_RELATIVE(self, relative):
         """Sets AT RELATIVE with string or component instance"""
 
-        # Extract name if component instance is given
-        if isinstance(relative, component):
+        # Extract name if Component instance is given
+        if isinstance(relative, Component):
             relative = relative.name
         elif not isinstance(relative, str):
             raise ValueError("Relative must be either string or "
-                             + "component object.")
+                             + "Component object.")
 
         # Set AT relative
         if relative == "ABSOLUTE":
@@ -600,15 +600,15 @@ class component:
             self.set_ROTATED_RELATIVE(RELATIVE)
 
     def set_ROTATED_RELATIVE(self, relative):
-        """Sets ROTATED RELATIVE with string or component instance"""
+        """Sets ROTATED RELATIVE with string or Component instance"""
 
         self.ROTATED_specified = True
-        # Extract name if a component instance is given
-        if isinstance(relative, component):
+        # Extract name if a Component instance is given
+        if isinstance(relative, Component):
             relative = relative.name
         elif not isinstance(relative, str):
             raise ValueError("Relative must be either string or "
-                             + "component object.")
+                             + "Component object.")
 
         # Set ROTATED relative
         if relative == "ABSOLUTE":
@@ -618,12 +618,12 @@ class component:
 
     def set_RELATIVE(self, relative):
         """Sets both AT_relative and ROTATED_relative"""
-        # Extract name if a component instance is given
-        if isinstance(relative, component):
+        # Extract name if a Component instance is given
+        if isinstance(relative, Component):
             relative = relative.name
         elif not isinstance(relative, str):
             raise ValueError("Relative must be either string or "
-                             + "component object.")
+                             + "Component object.")
 
         if relative == "ABSOLUTE":
             self.AT_relative = "ABSOLUTE"
@@ -634,10 +634,10 @@ class component:
 
     def set_parameters(self, dict_input):
         """
-        Set component parameters from dictionary input
+        Set Component parameters from dictionary input
 
         Relies on attributes added when McStas_Instr creates a subclass from
-        the component class where each component parameter is added as an
+        the Component class where each component parameter is added as an
         attribute.
 
         An error is raised if trying to set a parameter that does not exist

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -7,9 +7,9 @@ import subprocess
 import copy
 
 from mcstasscript.data.data import McStasData
-from mcstasscript.helper.mcstas_objects import declare_variable
-from mcstasscript.helper.mcstas_objects import parameter_variable
-from mcstasscript.helper.mcstas_objects import component
+from mcstasscript.helper.mcstas_objects import DeclareVariable
+from mcstasscript.helper.mcstas_objects import ParameterVariable
+from mcstasscript.helper.mcstas_objects import Component
 from mcstasscript.helper.component_reader import ComponentReader
 from mcstasscript.helper.managed_mcrun import ManagedMcrun
 from mcstasscript.helper.formatting import is_legal_filename
@@ -39,10 +39,10 @@ class McCode_instr:
     executable_path : str
         absolute path of mcrun command, or empty if it is in path
 
-    parameter_list : list of parameter_variable instances
+    parameter_list : list of ParameterVariable instances
         contains all input parameters to be written to file
 
-    declare_list : list of declare_variable instances
+    declare_list : list of DeclareVariable instances
         contains all declare parrameters to be written to file
 
     initialize_section : str
@@ -265,8 +265,8 @@ class McCode_instr:
             comment : str
                 Comment displayed next to declaration of parameter
         """
-        # parameter_variable class documented independently
-        self.parameter_list.append(parameter_variable(*args, **kwargs))
+        # ParameterVariable class documented independently
+        self.parameter_list.append(ParameterVariable(*args, **kwargs))
 
     def show_parameters(self, **kwargs):
         """
@@ -377,8 +377,8 @@ class McCode_instr:
                 Comment displayed next to declaration of parameter
 
         """
-        # declare_variable class documented independently
-        self.declare_list.append(declare_variable(*args, **kwargs))
+        # DeclareVariable class documented independently
+        self.declare_list.append(DeclareVariable(*args, **kwargs))
         
     def append_declare(self, string):
         """
@@ -578,21 +578,21 @@ class McCode_instr:
             input_dict["line_limit"] = self.line_limit
 
             self.component_class_lib[component_name] = type(component_name,
-                                                            (component,),
+                                                            (Component,),
                                                             input_dict)
 
         return self.component_class_lib[component_name](*args, **kwargs)
 
     def add_component(self, *args, **kwargs):
         """
-        Method for adding a new component instance to the instrument
+        Method for adding a new Component instance to the instrument
 
-        Creates a new component instance in the instrument.  This
+        Creates a new Component instance in the instrument.  This
         requires a unique instance name of the component to be used for
         future reference and the name of the McStas component to be
         used.  The component is placed at the end of the instrument file
         unless otherwise specified with the after and before keywords.
-        The component may be initialized using other keyword arguments,
+        The Component may be initialized using other keyword arguments,
         but all attributes can be set with approrpiate methods.
 
         Parameters
@@ -689,9 +689,9 @@ class McCode_instr:
     
     def copy_component(self, *args, **kwargs):
         """
-        Method for adding a copy of a component instance to the instrument
+        Method for adding a copy of a Component instance to the instrument
 
-        Creates a copy of component instance in the instrument.  This
+        Creates a copy of Component instance in the instrument.  This
         requires a unique instance name of the component to be used for
         future reference and the name of the McStas component to be
         used.  The component is placed at the end of the instrument file
@@ -1592,10 +1592,10 @@ class McStas_instr(McCode_instr):
     executable_path : str
         absolute path of mcrun command, or empty if it is in path
 
-    parameter_list : list of parameter_variable instances
+    parameter_list : list of ParameterVariable instances
         contains all input parameters to be written to file
 
-    declare_list : list of declare_variable instances
+    declare_list : list of DeclareVariable instances
         contains all declare parrameters to be written to file
 
     initialize_section : str
@@ -1773,10 +1773,10 @@ class McXtrace_instr(McCode_instr):
     executable_path : str
         absolute path of mcrun command, or empty if it is in path
 
-    parameter_list : list of parameter_variable instances
+    parameter_list : list of ParameterVariable instances
         contains all input parameters to be written to file
 
-    declare_list : list of declare_variable instances
+    declare_list : list of DeclareVariable instances
         contains all declare parrameters to be written to file
 
     initialize_section : str
@@ -1788,7 +1788,7 @@ class McXtrace_instr(McCode_instr):
     finally_section : str
         string containing entire finally section to be written
 
-    component_list : list of component instances
+    component_list : list of Component instances
         list of components in the instrument
 
     component_name_list : list of strings

--- a/mcstasscript/tests/test_ComponentReader.py
+++ b/mcstasscript/tests/test_ComponentReader.py
@@ -8,6 +8,11 @@ from mcstasscript.helper.component_reader import ComponentReader
 
 
 def setup_component_reader():
+    """
+    Sets up a component_reader instance with dummy mcstas
+    installation located in the tests directory
+    """
+
     THIS_DIR = os.path.dirname(os.path.abspath(__file__))
     dummy_path = os.path.join(THIS_DIR, "dummy_mcstas")
 
@@ -21,6 +26,11 @@ def setup_component_reader():
     return component_reader
 
 def setup_component_reader_input_path():
+    """
+    Sets up a component_reader instance with dummy mcstas
+    installation located in the tests directory, and specifies
+    a input_path which is also located in the test directory.
+    """
     THIS_DIR = os.path.dirname(os.path.abspath(__file__))
     dummy_path = os.path.join(THIS_DIR, "dummy_mcstas")
     input_path = os.path.join(THIS_DIR, "test_input_folder")
@@ -40,13 +50,14 @@ class TestComponentReader(unittest.TestCase):
     """
     Testing the ComponenReader class. As this class reads information
     from McStas, a dummy McStas install is made in the test folder to
-    avoid the test results changeing with updates of McStas.
+    avoid the test results changing with updates of McStas.
     """
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def test_ComponentReader_init_overwrite_message(self, mock_stdout):
         """
         Test that ComponentReader reports overwritten components
+        Here using default input path, which is current folder
         """
 
         component_reader = setup_component_reader()
@@ -62,6 +73,7 @@ class TestComponentReader(unittest.TestCase):
     def test_ComponentReader_init_overwrite_message_input(self, mock_stdout):
         """
         Test that ComponentReader reports overwritten components
+        Here using user defined input path, a directory in tests
         """
 
         component_reader = setup_component_reader_input_path()
@@ -466,7 +478,7 @@ class TestComponentReader(unittest.TestCase):
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def test_ComponentReader_read_component_int(self, mock_stdout):
         """
-        Test that a integer parameter is read correctly when reading a
+        Test that a integer parameter is read correctly when reading an
         component file.
         Has default, is int type (comments and unit checked already)
         """
@@ -516,50 +528,6 @@ class TestComponentReader(unittest.TestCase):
 
         self.assertNotIn("test_string", CompInfo.parameter_units)
         # Have already tested units are read
-
-    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
-    def test_ComponentReader_line_start_long(self, mock_stdout):
-        """
-        Helper function that should return true when certain string is
-        the start of another string.
-
-        """
-
-        component_reader = setup_component_reader()
-
-        test_string = "monkey wants banana"
-
-        return_val = component_reader.line_starts_with(test_string, "mo")
-        self.assertIsInstance(return_val, bool)
-        self.assertTrue(return_val)
-
-        return_val = component_reader.line_starts_with(test_string, "on")
-        self.assertIsInstance(return_val, bool)
-        self.assertFalse(return_val)
-
-    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
-    def test_ComponentReader_line_start_short(self, mock_stdout):
-        """
-        Helper function that should return true when certain string is
-        the start of another string. Here checked with short test_string
-
-        """
-
-        component_reader = setup_component_reader()
-
-        test_string = "m"
-
-        return_val = component_reader.line_starts_with(test_string, "m")
-        self.assertIsInstance(return_val, bool)
-        self.assertTrue(return_val)
-
-        return_val = component_reader.line_starts_with(test_string, "mo")
-        self.assertIsInstance(return_val, bool)
-        self.assertFalse(return_val)
-
-        return_val = component_reader.line_starts_with(test_string, "on")
-        self.assertIsInstance(return_val, bool)
-        self.assertFalse(return_val)
 
 
 if __name__ == '__main__':

--- a/mcstasscript/tests/test_Instr.py
+++ b/mcstasscript/tests/test_Instr.py
@@ -278,8 +278,8 @@ class TestMcStas_instr(unittest.TestCase):
         instr = setup_instr_root_path()
 
         instr.add_parameter("double", "theta", comment="test par")
-        instr.add_parameter("single", "theta", comment="test par")
-        instr.add_parameter("float", "theta", value=8, comment="test par")
+        instr.add_parameter("double", "theta", comment="test par")
+        instr.add_parameter("int", "theta", value=8, comment="test par")
         instr.add_parameter("int", "slits", comment="test par")
         instr.add_parameter("string", "ref",
                             value="string", comment="new string")
@@ -288,11 +288,11 @@ class TestMcStas_instr(unittest.TestCase):
 
         output = mock_stdout.getvalue().split("\n")
 
-        self.assertEqual(output[0], "double  theta             // test par")
-        self.assertEqual(output[1], "single  theta             // test par")
-        self.assertEqual(output[2], "float   theta  =  8       // test par")
-        self.assertEqual(output[3], "int     slits             // test par")
-        self.assertEqual(output[4], "string  ref    =  string  // new string")
+        self.assertEqual(output[0], "double theta             // test par")
+        self.assertEqual(output[1], "double theta             // test par")
+        self.assertEqual(output[2], "int    theta  =  8       // test par")
+        self.assertEqual(output[3], "int    slits             // test par")
+        self.assertEqual(output[4], "string ref    =  string  // new string")
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def test_show_parameters_line_break(self, mock_stdout):
@@ -305,8 +305,8 @@ class TestMcStas_instr(unittest.TestCase):
         instr = setup_instr_root_path()
 
         instr.add_parameter("double", "theta", comment="test par")
-        instr.add_parameter("single", "theta", comment="test par")
-        instr.add_parameter("float", "theta", value=8, comment="test par")
+        instr.add_parameter("double", "theta", comment="test par")
+        instr.add_parameter("int", "theta", value=8, comment="test par")
         instr.add_parameter("int", "slits", comment="test par")
         instr.add_parameter("string", "ref",
                             value="string", comment="new string")
@@ -324,22 +324,22 @@ class TestMcStas_instr(unittest.TestCase):
 
         output = mock_stdout.getvalue().split("\n")
 
-        self.assertEqual(output[0], "double  theta             // test par")
-        self.assertEqual(output[1], "single  theta             // test par")
-        self.assertEqual(output[2], "float   theta  =  8       // test par")
-        self.assertEqual(output[3], "int     slits             // test par")
-        self.assertEqual(output[4], "string  ref    =  string  // new string")
+        self.assertEqual(output[0], "double theta             // test par")
+        self.assertEqual(output[1], "double theta             // test par")
+        self.assertEqual(output[2], "int    theta  =  8       // test par")
+        self.assertEqual(output[3], "int    slits             // test par")
+        self.assertEqual(output[4], "string ref    =  string  // new string")
         comment_line = "This is a very long comment meant for testing "
-        self.assertEqual(output[5], "double  value  =  37      // "
+        self.assertEqual(output[5], "double value  =  37      // "
                                     + comment_line)
         comment_line = "the dynamic line breaking that is used in this "
-        self.assertEqual(output[6], "                             "
+        self.assertEqual(output[6], "                            "
                                     + comment_line)
         comment_line = "method. It needs to have many lines in order to "
-        self.assertEqual(output[7], "                             "
+        self.assertEqual(output[7], "                            "
                                     + comment_line)
         comment_line = "ensure it really works. "
-        self.assertEqual(output[8], "                             "
+        self.assertEqual(output[8], "                            "
                                     + comment_line)
 
     def test_simple_add_declare_parameter(self):
@@ -567,7 +567,7 @@ class TestMcStas_instr(unittest.TestCase):
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def test_show_components_input_path_simple(self, mock_stdout):
         """
-        Simple test of input_path being recoignized and passed
+        Simple test of input_path being recognized and passed
         to component_reader so PSDlin_monitor is overwritten
         """
         instr = setup_instr_with_input_path()
@@ -590,9 +590,9 @@ class TestMcStas_instr(unittest.TestCase):
         self.assertEqual(output[6], " Work directory")
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
-    def test_show_components_input_path_simple(self, mock_stdout):
+    def test_show_components_input_path_custom(self, mock_stdout):
         """
-        Simple test of input_path being recoignized and passed
+        Simple test of input_path being recognized and passed
         to component_reader so PSDlin_monitor is overwritten
         Here dummy_mcstas and input_path is set using relative
         paths instead of absolute paths.

--- a/mcstasscript/tests/test_Instr_reader.py
+++ b/mcstasscript/tests/test_Instr_reader.py
@@ -67,17 +67,17 @@ class TestInstrReader(unittest.TestCase):
         
         self.assertEqual(Instr.parameter_list[0].name, "stick_displacement")
         # space in type inserted for easier writing by McStas_Instr class
-        self.assertEqual(Instr.parameter_list[0].type, "double ")
+        self.assertEqual(Instr.parameter_list[0].type, "double")
         self.assertEqual(Instr.parameter_list[0].value, 0)
         
         self.assertEqual(Instr.parameter_list[1].name, "test_int")
         # space in type inserted for easier writing by McStas_Instr class
-        self.assertEqual(Instr.parameter_list[1].type, "int ")
+        self.assertEqual(Instr.parameter_list[1].type, "int")
         self.assertEqual(Instr.parameter_list[1].value, 3)
         
         self.assertEqual(Instr.parameter_list[2].name, "test_str")
         # space in type inserted for easier writing by McStas_Instr class
-        self.assertEqual(Instr.parameter_list[2].type, "string ")
+        self.assertEqual(Instr.parameter_list[2].type, "string")
         self.assertEqual(Instr.parameter_list[2].value, "\"\\\"hurray\\\"\"")
 
     def test_read_declare_parameter(self):

--- a/mcstasscript/tests/test_component.py
+++ b/mcstasscript/tests/test_component.py
@@ -3,16 +3,16 @@ import builtins
 import unittest
 import unittest.mock
 
-from mcstasscript.helper.mcstas_objects import component
+from mcstasscript.helper.mcstas_objects import Component
 from mcstasscript.helper.formatting import bcolors
 
 
-def setup_component_all_keywords():
+def setup_Component_all_keywords():
     """
-    Sets up a component by using all initialize keywords
+    Sets up a Component by using all initialize keywords
     """
 
-    return component("test_component",
+    return Component("test_component",
                      "Arm",
                      AT=[0.124, 183.9, 157],
                      AT_RELATIVE="home",
@@ -26,11 +26,11 @@ def setup_component_all_keywords():
                      comment="test comment")
 
 
-def setup_component_relative():
+def setup_Component_relative():
     """
-    Sets up a component with the relative keyword used
+    Sets up a Component with the relative keyword used
     """
-    return component("test_component",
+    return Component("test_component",
                      "Arm",
                      AT=[0.124, 183.9, 157],
                      ROTATED=[482, 1240.2, 0.185],
@@ -43,12 +43,12 @@ def setup_component_relative():
                      comment="test comment")
 
 
-def setup_component_with_parameters():
+def setup_Component_with_parameters():
     """
-    Sets up a component with parameters and all options used.
+    Sets up a Component with parameters and all options used.
 
     """
-    comp = setup_component_all_keywords()
+    comp = setup_Component_all_keywords()
 
     comp._unfreeze()
     # Need to set up attribute parameters
@@ -83,7 +83,7 @@ def setup_component_with_parameters():
     return comp
 
 
-class Testcomponent(unittest.TestCase):
+class TestComponent(unittest.TestCase):
     """
     Components are the building blocks used to create an instrument in
     the McStas meta language. They describe spatially seperated parts
@@ -91,23 +91,23 @@ class Testcomponent(unittest.TestCase):
     tested.
     """
 
-    def test_component_basic_init(self):
+    def test_Component_basic_init(self):
         """
         Testing basic initialization
 
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         self.assertEqual(comp.name, "test_component")
         self.assertEqual(comp.component_name, "Arm")
 
-    def test_component_basic_init_defaults(self):
+    def test_Component_basic_init_defaults(self):
         """
         Testing basic initialization sets the correct defaults
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         self.assertEqual(comp.name, "test_component")
         self.assertEqual(comp.component_name, "Arm")
@@ -121,12 +121,12 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.JUMP, "")
         self.assertEqual(comp.comment, "")
 
-    def test_component_init_complex_call(self):
+    def test_Component_init_complex_call(self):
         """
         Testing keywords set attributes correctly
         """
 
-        comp = setup_component_all_keywords()
+        comp = setup_Component_all_keywords()
 
         self.assertEqual(comp.name, "test_component")
         self.assertEqual(comp.component_name, "Arm")
@@ -141,12 +141,12 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.SPLIT, 7)
         self.assertEqual(comp.comment, "test comment")
 
-    def test_component_init_complex_call_relative(self):
+    def test_Component_init_complex_call_relative(self):
         """
         Tests the relative keyword overwrites AT_relative and
         ROTATED_relative
         """
-        comp = setup_component_relative()
+        comp = setup_Component_relative()
 
         self.assertEqual(comp.name, "test_component")
         self.assertEqual(comp.component_name, "Arm")
@@ -162,11 +162,11 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.comment, "test comment")
 
 
-    def test_component_basic_init_set_AT(self):
+    def test_Component_basic_init_set_AT(self):
         """
         Testing set_AT method
         """
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_AT([12.124, 214.0, 2], RELATIVE="monochromator")
 
@@ -175,12 +175,12 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.AT_data, [12.124, 214.0, 2])
         self.assertEqual(comp.AT_relative, "RELATIVE monochromator")
 
-    def test_component_freeze(self):
+    def test_Component_freeze(self):
         """
-        Testing frozen component cant have new attributes, and that
+        Testing frozen Component cant have new attributes, and that
         _unfreeze / _freeze works correctly.
         """
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         with self.assertRaises(AttributeError):
             comp.new_parameter = 5
@@ -197,13 +197,13 @@ class Testcomponent(unittest.TestCase):
         with self.assertRaises(AttributeError):
             comp.another_parameter = 5
 
-    def test_component_basic_init_set_AT_component(self):
+    def test_Component_basic_init_set_AT_Component(self):
         """
-        Testing set_AT method using component object and method
+        Testing set_AT method using Component object and method
         """
 
-        prev_component = component("relative_base", "Arm")
-        comp = component("test_component", "Arm")
+        prev_component = Component("relative_base", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_AT([12.124, 214.0, 2], RELATIVE=prev_component)
 
@@ -212,13 +212,13 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.AT_data, [12.124, 214.0, 2])
         self.assertEqual(comp.AT_relative, "RELATIVE relative_base")
 
-    def test_component_basic_init_set_AT_component_keyword(self):
+    def test_Component_basic_init_set_AT_Component_keyword(self):
         """
-        Testing set_AT method using component object and keyword argument
+        Testing set_AT method using Component object and keyword argument
         """
 
-        prev_component = component("relative_base", "Arm")
-        comp = component("test_component", "Arm",
+        prev_component = Component("relative_base", "Arm")
+        comp = Component("test_component", "Arm",
                          AT=[1, 2, 3.0], AT_RELATIVE=prev_component)
 
         self.assertEqual(comp.name, "test_component")
@@ -226,12 +226,12 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.AT_data, [1, 2, 3.0])
         self.assertEqual(comp.AT_relative, "RELATIVE relative_base")
 
-    def test_component_basic_init_set_ROTATED(self):
+    def test_Component_basic_init_set_ROTATED(self):
         """
         Testing set_ROTATED method med relative as string
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_ROTATED([1204.8, 8490.1, 129], RELATIVE="analyzer")
 
@@ -240,13 +240,13 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.ROTATED_data, [1204.8, 8490.1, 129])
         self.assertEqual(comp.ROTATED_relative, "RELATIVE analyzer")
 
-    def test_component_basic_init_set_ROTATED_component(self):
+    def test_Component_basic_init_set_ROTATED_Component(self):
         """
-        Testing set_ROTATED method with relative as component object
+        Testing set_ROTATED method with relative as Component object
         """
 
-        prev_component = component("relative_base", "Arm")
-        comp = component("test_component", "Arm")
+        prev_component = Component("relative_base", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_ROTATED([1204.8, 8490.1, 129], RELATIVE=prev_component)
 
@@ -255,13 +255,13 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.ROTATED_data, [1204.8, 8490.1, 129])
         self.assertEqual(comp.ROTATED_relative, "RELATIVE relative_base")
 
-    def test_component_basic_init_set_ROTATED_component_keyword(self):
+    def test_Component_basic_init_set_ROTATED_Component_keyword(self):
         """
-        Testing setting ROTATION with keyword and component object input
+        Testing setting ROTATION with keyword and Component object input
         """
 
-        prev_component = component("relative_base", "Arm")
-        comp = component("test_component", "Arm",
+        prev_component = Component("relative_base", "Arm")
+        comp = Component("test_component", "Arm",
                          ROTATED=[1, 2, 3.0], ROTATED_RELATIVE=prev_component)
 
         self.assertEqual(comp.name, "test_component")
@@ -269,12 +269,12 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.ROTATED_data, [1, 2, 3.0])
         self.assertEqual(comp.ROTATED_relative, "RELATIVE relative_base")
 
-    def test_component_basic_init_set_RELATIVE(self):
+    def test_Component_basic_init_set_RELATIVE(self):
         """
         Testing set_RELATIVE method with string
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_RELATIVE("sample")
 
@@ -283,13 +283,13 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.AT_relative, "RELATIVE sample")
         self.assertEqual(comp.ROTATED_relative, "RELATIVE sample")
 
-    def test_component_basic_init_set_RELATIVE(self):
+    def test_Component_basic_init_set_RELATIVE(self):
         """
-        Testing set_RELATIVE method with component object input
+        Testing set_RELATIVE method with Component object input
         """
 
-        prev_component = component("relative_base", "Arm")
-        comp = component("test_component", "Arm")
+        prev_component = Component("relative_base", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_RELATIVE(prev_component)
 
@@ -304,7 +304,7 @@ class Testcomponent(unittest.TestCase):
         parameters manually to test this.
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         # Need to add some parameters to this bare component
         # Parameters are usually added by McStas_Instr
@@ -326,12 +326,12 @@ class Testcomponent(unittest.TestCase):
         with self.assertRaises(NameError):
             comp.set_parameters({"new_par3": 37.0})
 
-    def test_component_basic_init_set_WHEN(self):
+    def test_Component_basic_init_set_WHEN(self):
         """
         Testing WHEN method
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_WHEN("1 != 2")
 
@@ -339,12 +339,12 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.component_name, "Arm")
         self.assertEqual(comp.WHEN, "WHEN (1 != 2)")
 
-    def test_component_basic_init_set_GROUP(self):
+    def test_Component_basic_init_set_GROUP(self):
         """
         Testing set_GROUP method
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_GROUP("test group")
 
@@ -352,12 +352,12 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.component_name, "Arm")
         self.assertEqual(comp.GROUP, "test group")
 
-    def test_component_basic_init_set_JUMP(self):
+    def test_Component_basic_init_set_JUMP(self):
         """
         Testing set_JUMP method
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_JUMP("test jump")
 
@@ -365,12 +365,12 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.component_name, "Arm")
         self.assertEqual(comp.JUMP, "test jump")
         
-    def test_component_basic_init_set_SPLIT(self):
+    def test_Component_basic_init_set_SPLIT(self):
         """
         Testing set_SPLIT method
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_SPLIT(500)
 
@@ -378,12 +378,12 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.component_name, "Arm")
         self.assertEqual(comp.SPLIT, 500)
 
-    def test_component_basic_init_set_EXTEND(self):
+    def test_Component_basic_init_set_EXTEND(self):
         """
         Testing set_EXTEND method
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.append_EXTEND("test code")
 
@@ -395,11 +395,11 @@ class Testcomponent(unittest.TestCase):
 
         self.assertEqual(comp.EXTEND, "test code\nnew code\n")
 
-    def test_component_basic_init_set_comment(self):
+    def test_Component_basic_init_set_comment(self):
         """
         Testing set_comment method
         """
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp.set_comment("test comment")
 
@@ -407,14 +407,14 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(comp.component_name, "Arm")
         self.assertEqual(comp.comment, "test comment")
 
-    def test_component_basic_new_attribute_error(self):
+    def test_Component_basic_new_attribute_error(self):
         """
-        The component class is frozen after initialize in order to
+        The Component class is frozen after initialize in order to
         prevent the user accidentilly misspelling an attribute name,
         or at least be able to report an error when they do so.
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
         with self.assertRaises(AttributeError):
             comp.new_attribute = 1
 
@@ -424,13 +424,13 @@ class Testcomponent(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_component_write_to_file_simple(self, mock_f):
+    def test_Component_write_to_file_simple(self, mock_f):
         """
-        Testing that a component can be written to file with the
+        Testing that a Component can be written to file with the
         expected output. Here with simple input.
         """
 
-        comp = component("test_component", "Arm")
+        comp = Component("test_component", "Arm")
 
         comp._unfreeze()
         # Need to set up attribute parameters
@@ -455,13 +455,13 @@ class Testcomponent(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)    
-    def test_component_write_to_file_include(self, mock_f):
+    def test_Component_write_to_file_include(self, mock_f):
         """
-        Testing that a component can be written to file with the
+        Testing that a Component can be written to file with the
         expected output. Here with simple input.
         """
 
-        comp = component("test_component", "Arm",
+        comp = Component("test_component", "Arm",
                          c_code_before="%include \"test.instr\"")
         
         comp.set_c_code_after("%include \"after.instr\"")
@@ -496,13 +496,13 @@ class Testcomponent(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_component_write_to_file_complex(self, mock_f):
+    def test_Component_write_to_file_complex(self, mock_f):
         """
-        Testing that a component can be written to file with the
+        Testing that a Component can be written to file with the
         expected output. Here with complex input.
         """
 
-        comp = setup_component_with_parameters()
+        comp = setup_Component_with_parameters()
 
         # This setup has a required parameter.
         # If this parameter is not set, an error should be returned,
@@ -547,14 +547,14 @@ class Testcomponent(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_component_write_to_file_complex_SPLIT_string(self, mock_f):
+    def test_Component_write_to_file_complex_SPLIT_string(self, mock_f):
         """
-        Testing that a component can be written to file with the
+        Testing that a Component can be written to file with the
         expected output. Here with complex input, and a string as
         given for split.
         """
 
-        comp = setup_component_with_parameters()
+        comp = setup_Component_with_parameters()
         comp.set_SPLIT("VAR")
 
         # This setup has a required parameter.
@@ -600,13 +600,13 @@ class Testcomponent(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_component_write_component_required_parameter_error(self, mock_f):
+    def test_Component_write_Component_required_parameter_error(self, mock_f):
         """
-        Test an error occurs if the component is asked to write to disk
+        Test an error occurs if the Component is asked to write to disk
         without a required parameter.
         """
 
-        comp = setup_component_with_parameters()
+        comp = setup_Component_with_parameters()
 
         # new_par3 unset and has no default so an error will be raised
 
@@ -615,13 +615,13 @@ class Testcomponent(unittest.TestCase):
                 comp.write_component(m_fo)
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
-    def test_component_print_long(self, mock_stdout):
+    def test_Component_print_long(self, mock_stdout):
         """
-        Test print to console on the current state of the component.
+        Test print to console on the current state of the Component.
         Using a mocked stdout to catch the print statements.
         """
 
-        comp = setup_component_with_parameters()
+        comp = setup_Component_with_parameters()
         comp.append_EXTEND("second extend line;")
 
         comp.print_long()
@@ -671,13 +671,13 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(output[15], "JUMP myself 37")
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
-    def test_component_print_short_standard(self, mock_stdout):
+    def test_Component_print_short_standard(self, mock_stdout):
         """
         Test print_short that prints name, type and location of the
-        component to the console.
+        Component to the console.
         """
 
-        comp = setup_component_with_parameters()
+        comp = setup_Component_with_parameters()
 
         comp.print_short()
 
@@ -691,13 +691,13 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(output[0], expected)
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
-    def test_component_print_short_longest_name(self, mock_stdout):
+    def test_Component_print_short_longest_name(self, mock_stdout):
         """
         Test print_short that prints name, type and location of the
-        component to the console. Here with specified longest_name.
+        Component to the console. Here with specified longest_name.
         """
 
-        comp = setup_component_with_parameters()
+        comp = setup_Component_with_parameters()
 
         comp.print_short(longest_name=15)
 
@@ -711,14 +711,14 @@ class Testcomponent(unittest.TestCase):
         self.assertEqual(output[0], expected)
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
-    def test_component_show_parameters(self, mock_stdout):
+    def test_Component_show_parameters(self, mock_stdout):
         """
         Test print_short that prints name, type and location of the
-        component to the console. An extra parameter was added.
+        Component to the console. An extra parameter was added.
         This test also checks for specific formatting.
         """
 
-        comp = setup_component_with_parameters()
+        comp = setup_Component_with_parameters()
 
         comp._unfreeze()
 
@@ -787,14 +787,14 @@ class Testcomponent(unittest.TestCase):
                          par_name + " = " + value + " [1]" + comment)
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
-    def test_component_show_parameters_simple(self, mock_stdout):
+    def test_Component_show_parameters_simple(self, mock_stdout):
         """
         Test print_short that prints name, type and location of the
-        component to the console.  No formatting used in simple
+        Component to the console.  No formatting used in simple
         version.
         """
 
-        comp = setup_component_with_parameters()
+        comp = setup_Component_with_parameters()
 
         comp._unfreeze()
 

--- a/mcstasscript/tests/test_declare_variable.py
+++ b/mcstasscript/tests/test_declare_variable.py
@@ -21,7 +21,7 @@ class Test_declare_variable(unittest.TestCase):
         var = declare_variable("double", "test")
 
         self.assertEqual(var.name, "test")
-        self.assertEqual(var.type, "double")  # space for easier writing
+        self.assertEqual(var.type, "double")
 
     def test_declare_variable_init_basic_type_value(self):
         """
@@ -31,7 +31,7 @@ class Test_declare_variable(unittest.TestCase):
         var = declare_variable("double", "test", value=518)
 
         self.assertEqual(var.name, "test")
-        self.assertEqual(var.type, "double")  # space for easier writing
+        self.assertEqual(var.type, "double")
         self.assertEqual(var.value, 518)
 
     def test_declare_variable_init_basic_type_vector(self):
@@ -82,7 +82,7 @@ class Test_declare_variable(unittest.TestCase):
                          new_callable=unittest.mock.mock_open)
     def test_declare_variable_write_complex_float(self, mock_f):
         """
-        Testing that write to file is correct. Here a line is in a
+        Testing that write to file is correct. Here a line is in an
         instrument declare section. The write file operation is
         mocked and check using a patch. Here a declare with a value
         is used. (float value)
@@ -106,7 +106,7 @@ class Test_declare_variable(unittest.TestCase):
                          new_callable=unittest.mock.mock_open)
     def test_declare_variable_write_complex_int(self, mock_f):
         """
-        Testing that write to file is correct. Here a line is in a
+        Testing that write to file is correct. Here a line is in an
         instrument declare section. The write file operation is
         mocked and check using a patch. Here a declare with a value
         is used. (integer value)
@@ -130,7 +130,7 @@ class Test_declare_variable(unittest.TestCase):
                          new_callable=unittest.mock.mock_open)
     def test_declare_variable_write_simple_array(self, mock_f):
         """
-        Testing that write to file is correct. Here a line is in a
+        Testing that write to file is correct. Here a line is in an
         instrument declare section. The write file operation is
         mocked and check using a patch. Here an array is declared.
         """
@@ -153,9 +153,9 @@ class Test_declare_variable(unittest.TestCase):
                          new_callable=unittest.mock.mock_open)
     def test_declare_variable_write_complex_array(self, mock_f):
         """
-        Testing that write to file is correct. Here a line is in a
+        Testing that write to file is correct. Here a line is in an
         instrument declare section. The write file operation is
-        mocked and check using a patch. Here an array is decalred and
+        mocked and check using a patch. Here an array is declared and
         populated with the selected values.
         """
 

--- a/mcstasscript/tests/test_declare_variable.py
+++ b/mcstasscript/tests/test_declare_variable.py
@@ -3,43 +3,43 @@ import builtins
 import unittest
 import unittest.mock
 
-from mcstasscript.helper.mcstas_objects import declare_variable
+from mcstasscript.helper.mcstas_objects import DeclareVariable
 
 
-class Test_declare_variable(unittest.TestCase):
+class Test_DeclareVariable(unittest.TestCase):
     """
-    Tests the declare_variable class that holds a declared variable
+    Tests the DeclareVariable class that holds a declared variable
     that will be written to the McStas declare section.
 
     """
 
-    def test_declare_variable_init_basic_type(self):
+    def test_DeclareVariable_init_basic_type(self):
         """
         Initialization with a type
         """
 
-        var = declare_variable("double", "test")
+        var = DeclareVariable("double", "test")
 
         self.assertEqual(var.name, "test")
         self.assertEqual(var.type, "double")
 
-    def test_declare_variable_init_basic_type_value(self):
+    def test_DeclareVariable_init_basic_type_value(self):
         """
         Initialization with type and value
         """
 
-        var = declare_variable("double", "test", value=518)
+        var = DeclareVariable("double", "test", value=518)
 
         self.assertEqual(var.name, "test")
         self.assertEqual(var.type, "double")
         self.assertEqual(var.value, 518)
 
-    def test_declare_variable_init_basic_type_vector(self):
+    def test_DeclareVariable_init_basic_type_vector(self):
         """
         Initialization with type and value
         """
 
-        var = declare_variable("double", "test",
+        var = DeclareVariable("double", "test",
                                array=6, value=[1, 2.2, 3, 3.3, 4, 4.4])
 
         self.assertEqual(var.name, "test")
@@ -47,12 +47,12 @@ class Test_declare_variable(unittest.TestCase):
         self.assertEqual(var.vector, 6)
         self.assertEqual(var.value, [1, 2.2, 3, 3.3, 4, 4.4])
 
-    def test_declare_variable_init_basic_type_value_comment(self):
+    def test_DeclareVariable_init_basic_type_value_comment(self):
         """
         Initialization with type, value and comment
         """
 
-        var = declare_variable("double", "test",
+        var = DeclareVariable("double", "test",
                                value=518, comment="test comment /")
 
         self.assertEqual(var.name, "test")
@@ -62,7 +62,7 @@ class Test_declare_variable(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_declare_variable_write_basic(self, mock_f):
+    def test_DeclareVariable_write_basic(self, mock_f):
         """
         Testing that write to file is correct. Here a line is in a
         instrument declare section. The write file operation is
@@ -70,7 +70,7 @@ class Test_declare_variable(unittest.TestCase):
         used.
         """
 
-        var = declare_variable("double", "test")
+        var = DeclareVariable("double", "test")
         with mock_f('test.txt', 'w') as m_fo:
             var.write_line(m_fo)
 
@@ -80,7 +80,7 @@ class Test_declare_variable(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_declare_variable_write_complex_float(self, mock_f):
+    def test_DeclareVariable_write_complex_float(self, mock_f):
         """
         Testing that write to file is correct. Here a line is in an
         instrument declare section. The write file operation is
@@ -88,7 +88,7 @@ class Test_declare_variable(unittest.TestCase):
         is used. (float value)
         """
 
-        var = declare_variable("double",
+        var = DeclareVariable("double",
                                "test",
                                value=5.4,
                                comment="test comment")
@@ -104,7 +104,7 @@ class Test_declare_variable(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_declare_variable_write_complex_int(self, mock_f):
+    def test_DeclareVariable_write_complex_int(self, mock_f):
         """
         Testing that write to file is correct. Here a line is in an
         instrument declare section. The write file operation is
@@ -112,7 +112,7 @@ class Test_declare_variable(unittest.TestCase):
         is used. (integer value)
         """
 
-        var = declare_variable("double",
+        var = DeclareVariable("double",
                                "test",
                                value=5,
                                comment="test comment")
@@ -128,14 +128,14 @@ class Test_declare_variable(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_declare_variable_write_simple_array(self, mock_f):
+    def test_DeclareVariable_write_simple_array(self, mock_f):
         """
         Testing that write to file is correct. Here a line is in an
         instrument declare section. The write file operation is
         mocked and check using a patch. Here an array is declared.
         """
 
-        var = declare_variable("double",
+        var = DeclareVariable("double",
                                "test",
                                array=29,
                                comment="test comment")
@@ -151,7 +151,7 @@ class Test_declare_variable(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_declare_variable_write_complex_array(self, mock_f):
+    def test_DeclareVariable_write_complex_array(self, mock_f):
         """
         Testing that write to file is correct. Here a line is in an
         instrument declare section. The write file operation is
@@ -159,7 +159,7 @@ class Test_declare_variable(unittest.TestCase):
         populated with the selected values.
         """
 
-        var = declare_variable("double",
+        var = DeclareVariable("double",
                                "test",
                                array=3,
                                value=[5, 4, 3.1],

--- a/mcstasscript/tests/test_functions.py
+++ b/mcstasscript/tests/test_functions.py
@@ -291,7 +291,7 @@ class Test_load_data(unittest.TestCase):
     tested elsewhere. Since the load data is tested elsewhere, this
     function has just a single test to check the interface.
     """
-    def test_crun_load_data_PSD4PI(self):
+    def test_mcrun_load_data_PSD4PI(self):
         """
         Use test_data_set to test load_data for PSD_4PI
         """

--- a/mcstasscript/tests/test_parameter_variable.py
+++ b/mcstasscript/tests/test_parameter_variable.py
@@ -29,7 +29,7 @@ class Test_parameter_variable(unittest.TestCase):
         par = parameter_variable("double", "test")
 
         self.assertEqual(par.name, "test")
-        self.assertEqual(par.type, "double ")  # space for easier writing
+        self.assertEqual(par.type, "double")
 
     def test_parameter_variable_init_basic_type_value(self):
         """
@@ -39,7 +39,7 @@ class Test_parameter_variable(unittest.TestCase):
         par = parameter_variable("double", "test", value=518)
 
         self.assertEqual(par.name, "test")
-        self.assertEqual(par.type, "double ")  # space for easier writing
+        self.assertEqual(par.type, "double")
         self.assertEqual(par.value, 518)
 
     def test_parameter_variable_init_basic_type_value_comment(self):
@@ -51,7 +51,7 @@ class Test_parameter_variable(unittest.TestCase):
                                  value=518, comment="test comment /")
 
         self.assertEqual(par.name, "test")
-        self.assertEqual(par.type, "double ")  # space for easier writing
+        self.assertEqual(par.type, "double")
         self.assertEqual(par.value, 518)
         self.assertEqual(par.comment, "// test comment /")
 
@@ -72,7 +72,7 @@ class Test_parameter_variable(unittest.TestCase):
                          new_callable=unittest.mock.mock_open)
     def test_parameter_variable_write_basic(self, mock_f):
         """
-        Testing that write to file is correct. Here a line is in a
+        Testing that write to file is correct. Here a line is in an
         instrument parameter section. The write file operation is
         mocked and check using a patch. Here a simple parameter is
         used.
@@ -95,7 +95,7 @@ class Test_parameter_variable(unittest.TestCase):
                          new_callable=unittest.mock.mock_open)
     def test_parameter_variable_write_complex_float(self, mock_f):
         """
-        Testing that write to file is correct. Here a line is in a
+        Testing that write to file is correct. Here a line is in an
         instrument parameter section. The write file operation is
         mocked and check using a patch. Here a parameter with a value
         is used. (float value)
@@ -123,7 +123,7 @@ class Test_parameter_variable(unittest.TestCase):
                          new_callable=unittest.mock.mock_open)
     def test_parameter_variable_write_complex_int(self, mock_f):
         """
-        Testing that write to file is correct. Here a line is in a
+        Testing that write to file is correct. Here a line is in an
         instrument parameter section. The write file operation is
         mocked and check using a patch. Here a parameter with a value
         is used. (integer value)
@@ -151,7 +151,7 @@ class Test_parameter_variable(unittest.TestCase):
                          new_callable=unittest.mock.mock_open)
     def test_parameter_variable_write_complex_string(self, mock_f):
         """
-        Testing that write to file is correct. Here a line is in a
+        Testing that write to file is correct. Here a line is in an
         instrument parameter section. The write file operation is
         mocked and check using a patch. Here a parameter with a value
         is used. (string value)

--- a/mcstasscript/tests/test_parameter_variable.py
+++ b/mcstasscript/tests/test_parameter_variable.py
@@ -3,65 +3,65 @@ import builtins
 import unittest
 import unittest.mock
 
-from mcstasscript.helper.mcstas_objects import parameter_variable
+from mcstasscript.helper.mcstas_objects import ParameterVariable
 
 
-class Test_parameter_variable(unittest.TestCase):
+class Test_ParameterVariable(unittest.TestCase):
     """
-    Tests the parameter_variable class that holds an input parameter
+    Tests the ParameterVariable class that holds an input parameter
     for the instrument.
 
     """
 
-    def test_parameter_variable_init_basic(self):
+    def test_ParameterVariable_init_basic(self):
         """
         Smallest possible initialization
         """
 
-        par = parameter_variable("test")
+        par = ParameterVariable("test")
         self.assertEqual(par.name, "test")
 
-    def test_parameter_variable_init_basic_type(self):
+    def test_ParameterVariable_init_basic_type(self):
         """
         Initialization with a type
         """
 
-        par = parameter_variable("double", "test")
+        par = ParameterVariable("double", "test")
 
         self.assertEqual(par.name, "test")
         self.assertEqual(par.type, "double")
 
-    def test_parameter_variable_init_basic_type_value(self):
+    def test_ParameterVariable_init_basic_type_value(self):
         """
         Initialization with type and value
         """
 
-        par = parameter_variable("double", "test", value=518)
+        par = ParameterVariable("double", "test", value=518)
 
         self.assertEqual(par.name, "test")
         self.assertEqual(par.type, "double")
         self.assertEqual(par.value, 518)
 
-    def test_parameter_variable_init_basic_type_value_comment(self):
+    def test_ParameterVariable_init_basic_type_value_comment(self):
         """
         Initialization with type, value and comment
         """
 
-        par = parameter_variable("double", "test",
-                                 value=518, comment="test comment /")
+        par = ParameterVariable("double", "test", value=518,
+                                comment="test comment /")
 
         self.assertEqual(par.name, "test")
         self.assertEqual(par.type, "double")
         self.assertEqual(par.value, 518)
         self.assertEqual(par.comment, "// test comment /")
 
-    def test_parameter_variable_init_basic_value_comment(self):
+    def test_ParameterVariable_init_basic_value_comment(self):
         """
         Initialization with value and comment
         """
 
-        par = parameter_variable("test",
-                                 value=518, comment="test comment /")
+        par = ParameterVariable("test", value=518,
+                                comment="test comment /")
 
         self.assertEqual(par.name, "test")
         self.assertEqual(par.type, "")
@@ -70,7 +70,7 @@ class Test_parameter_variable(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_parameter_variable_write_basic(self, mock_f):
+    def test_ParameterVariable_write_basic(self, mock_f):
         """
         Testing that write to file is correct. Here a line is in an
         instrument parameter section. The write file operation is
@@ -78,7 +78,7 @@ class Test_parameter_variable(unittest.TestCase):
         used.
         """
 
-        par = parameter_variable("double", "test")
+        par = ParameterVariable("double", "test")
         with mock_f('test.txt', 'w') as m_fo:
             par.write_parameter(m_fo, "")
 
@@ -93,7 +93,7 @@ class Test_parameter_variable(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_parameter_variable_write_complex_float(self, mock_f):
+    def test_ParameterVariable_write_complex_float(self, mock_f):
         """
         Testing that write to file is correct. Here a line is in an
         instrument parameter section. The write file operation is
@@ -101,10 +101,8 @@ class Test_parameter_variable(unittest.TestCase):
         is used. (float value)
         """
 
-        par = parameter_variable("double",
-                                 "test",
-                                 value=5.4,
-                                 comment="test comment")
+        par = ParameterVariable("double", "test", value=5.4,
+                                comment="test comment")
 
         with mock_f('test.txt', 'w') as m_fo:
             par.write_parameter(m_fo, ")")
@@ -121,7 +119,7 @@ class Test_parameter_variable(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_parameter_variable_write_complex_int(self, mock_f):
+    def test_ParameterVariable_write_complex_int(self, mock_f):
         """
         Testing that write to file is correct. Here a line is in an
         instrument parameter section. The write file operation is
@@ -129,10 +127,8 @@ class Test_parameter_variable(unittest.TestCase):
         is used. (integer value)
         """
 
-        par = parameter_variable("double",
-                                 "test",
-                                 value=5,
-                                 comment="test comment")
+        par = ParameterVariable("double", "test", value=5,
+                                comment="test comment")
 
         with mock_f('test.txt', 'w') as m_fo:
             par.write_parameter(m_fo, ")")
@@ -149,7 +145,7 @@ class Test_parameter_variable(unittest.TestCase):
 
     @unittest.mock.patch('__main__.__builtins__.open',
                          new_callable=unittest.mock.mock_open)
-    def test_parameter_variable_write_complex_string(self, mock_f):
+    def test_ParameterVariable_write_complex_string(self, mock_f):
         """
         Testing that write to file is correct. Here a line is in an
         instrument parameter section. The write file operation is
@@ -157,9 +153,7 @@ class Test_parameter_variable(unittest.TestCase):
         is used. (string value)
         """
 
-        par = parameter_variable("double",
-                                 "test",
-                                 value="\"Al\"",
+        par = ParameterVariable("double", "test", value="\"Al\"",
                                  comment="test comment")
 
         with mock_f('test.txt', 'w') as m_fo:


### PR DESCRIPTION
Correction to McStasScript after review by Celine Durniak.



    Addressing review comments from Celine Durniak, much appreciated!
    
    The review concerns McStas objects and their tests.
    
    Fixed typos in docstrings and comments.
    
    Documented missing methods in docstrings.
    
    Added input sanitation for parameters, declare variable and some
    component methods.
    
    Added the option of specifying a float to set_AT instead of a list,
    as the most common use is just a distance in the z direction.
    
    Simplified path handling in component_reader
    
    Converted to built-in startswith method instead of adding my own method.
    
    Added a test for checking _freeze and _unfreeze methods on component.
    
    Added test for SPLIT number being a variable.
    
    Declare variable and parameter had different behavior in terms of
    spacing after type, this was simplified so only one convention is
    used, which incliudes no additional spaces.
    
    Ensured that tests fail when targets are changed after concern
    expressed by reviewer.

    Updated class names to CamelCase
    parameter_variable -> ParamterVariable
    declare_variable -> DeclareVariable
    component -> Component
