### PR TITLE
Libpyvinyl par fix

### DIFF
--- a/mcstasscript/helper/mcstas_objects.py
+++ b/mcstasscript/helper/mcstas_objects.py
@@ -2,7 +2,6 @@ from mcstasscript.helper.formatting import bcolors
 from mcstasscript.helper.formatting import is_legal_parameter
 
 from libpyvinyl.Parameters.Parameter import Parameter
-from libpyvinyl.Parameters.Collections import CalculatorParameters
 
 
 def provide_parameter(*args, **kwargs):
@@ -33,11 +32,14 @@ def provide_parameter(*args, **kwargs):
         Name of input parameter
 
     Keyword arguments
-        value : any
+        value : float, int or str
             sets default value of parameter
+        unit : str
+            string that describes the unit
         comment : str
             sets comment displayed next to declaration
-
+        options : list or value
+            list or value of allowed values for this parameter
     """
     if len(args) == 0:
         # Check all required keyword arguments present
@@ -111,6 +113,21 @@ def provide_parameter(*args, **kwargs):
 
 
 def write_parameter(fo, parameter, stop_character):
+    """
+    Writes a parameter object to McStas define section
+
+    Parameters
+    ----------
+
+    fo : file object
+        Open file object to write parameter string to
+
+    parameter : Parameter
+        Parameter object to be written
+
+    stop_character : str
+        Character inserted after parameter, usually comma and space
+    """
     if not isinstance(stop_character, str):
         raise RuntimeError("stop_character in write_parameter should be "
                            + "a string.")

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -298,6 +298,7 @@ class McCode_instr(BaseCalculator):
             elif isinstance(parameter.value, (str)):
                 parameter.type = "string"
             else:
+                # They will be typed when the instrument is written
                 parameter.type = None
 
         self._run_settings = {}  # Settings for running simulation
@@ -392,7 +393,7 @@ class McCode_instr(BaseCalculator):
         Method for adding input parameter to instrument
 
         Type does not need to be specified, McStas considers that a floating
-        point value with the type double. Uses libpyvinyl Parameter object.
+        point value with the type 'double'. Uses libpyvinyl Parameter object.
 
         Examples
         --------
@@ -423,6 +424,9 @@ class McCode_instr(BaseCalculator):
 
             comment : str
                 Comment displayed next to declaration of parameter
+
+            options : list or value
+                list or value of allowed values for this parameter
         """
         par = provide_parameter(*args, **kwargs)
         self.parameters.add(par)

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -293,7 +293,7 @@ class McCode_instr(BaseCalculator):
 
         # Attempt to classify given parameters in McStas context
         for parameter in self.parameters.parameters.values():
-            if parameter.value is None or isinstance(parameter.value, (float, int)):
+            if isinstance(parameter.value, (float, int)):
                 parameter.type = "double"
             elif isinstance(parameter.value, (str)):
                 parameter.type = "string"

--- a/mcstasscript/tests/test_Instr.py
+++ b/mcstasscript/tests/test_Instr.py
@@ -5,10 +5,12 @@ import unittest
 import unittest.mock
 import datetime
 
+from libpyvinyl.Parameters.Collections import CalculatorParameters
+
 from mcstasscript.interface.instr import McStas_instr
 from mcstasscript.interface.instr import McXtrace_instr
 from mcstasscript.helper.formatting import bcolors
-from .helpers_for_tests import WorkInTestDir
+from mcstasscript.tests.helpers_for_tests import WorkInTestDir
 
 run_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '.')
 
@@ -347,6 +349,32 @@ class TestMcStas_instr(unittest.TestCase):
         self.assertEqual(my_instrument._run_settings["executable_path"], correct_mxrun_path)
         self.assertEqual(my_instrument._run_settings["package_path"], correct_mcxtrace_path)
         self.assertEqual(my_instrument.line_limit, correct_n_of_characters)
+
+    def test_load_libpyvinyl_parameters(self):
+        parameters = CalculatorParameters()
+        int_par = parameters.new_parameter("int_parameter", comment="integer parameter")
+        int_par.value = 3
+
+        double_par = parameters.new_parameter("double_parameter", unit="meV")
+        double_par.value = 3.0
+
+        string_par = parameters.new_parameter("string_parameter")
+        string_par.value = "hello world"
+
+        secret_par = parameters.new_parameter("no_value_par")
+
+        instr = McStas_instr("test_instr", parameters=parameters)
+
+        self.assertEqual(int_par.type, "double")
+        self.assertEqual(double_par.type, "double")
+        self.assertEqual(string_par.type, "string")
+        self.assertEqual(secret_par.type, None)
+
+        instr.set_parameters(int_parameter=4)
+        self.assertEqual(int_par.value, 4)
+
+        int_par.value = 5
+        self.assertEqual(instr.parameters["int_parameter"].value, 5)
 
     def test_simple_add_parameter(self):
         """

--- a/mcstasscript/tests/test_dump_and_load.py
+++ b/mcstasscript/tests/test_dump_and_load.py
@@ -7,8 +7,6 @@ import datetime
 
 from mcstasscript.interface.instr import McStas_instr
 from mcstasscript.interface.instr import McXtrace_instr
-from mcstasscript.helper.mcstas_objects import ParameterContainer
-from mcstasscript.helper.mcstas_objects import ParameterVariable
 
 from .helpers_for_tests import WorkInTestDir
 

--- a/mcstasscript/tests/test_parameter_variable.py
+++ b/mcstasscript/tests/test_parameter_variable.py
@@ -1,8 +1,8 @@
 import unittest
 import unittest.mock
 
-from mcstasscript.helper.mcstas_objects import ParameterVariable
-
+from mcstasscript.helper.mcstas_objects import provide_parameter
+from mcstasscript.helper.mcstas_objects import write_parameter
 
 class Test_ParameterVariable(unittest.TestCase):
     """
@@ -16,7 +16,7 @@ class Test_ParameterVariable(unittest.TestCase):
         Smallest possible initialization
         """
 
-        par = ParameterVariable("test")
+        par = provide_parameter("test")
         self.assertEqual(par.name, "test")
 
     def test_ParameterVariable_init_basic_type(self):
@@ -24,7 +24,7 @@ class Test_ParameterVariable(unittest.TestCase):
         Initialization with a type
         """
 
-        par = ParameterVariable("double", "test")
+        par = provide_parameter("double", "test")
 
         self.assertEqual(par.name, "test")
         self.assertEqual(par.type, "double")
@@ -34,7 +34,7 @@ class Test_ParameterVariable(unittest.TestCase):
         Initialization with type and value
         """
 
-        par = ParameterVariable("double", "test", value=518)
+        par = provide_parameter("double", "test", value=518)
 
         self.assertEqual(par.name, "test")
         self.assertEqual(par.type, "double")
@@ -45,7 +45,7 @@ class Test_ParameterVariable(unittest.TestCase):
         Initialization with type, value and comment
         """
 
-        par = ParameterVariable("double", "test", value=518,
+        par = provide_parameter("double", "test", value=518,
                                 comment="test comment /")
 
         self.assertEqual(par.name, "test")
@@ -58,7 +58,7 @@ class Test_ParameterVariable(unittest.TestCase):
         Initialization with value and comment
         """
 
-        par = ParameterVariable("test", value=518,
+        par = provide_parameter("test", value=518,
                                 comment="test comment /")
 
         self.assertEqual(par.name, "test")
@@ -71,7 +71,7 @@ class Test_ParameterVariable(unittest.TestCase):
         Initialization with value and comment
         """
 
-        par = ParameterVariable("test", value=2,
+        par = provide_parameter("test", value=2,
                                 options=[1, 2, 3.1])
 
         self.assertEqual(par.name, "test")
@@ -89,9 +89,9 @@ class Test_ParameterVariable(unittest.TestCase):
         used.
         """
 
-        par = ParameterVariable("double", "test")
+        par = provide_parameter("double", "test")
         with mock_f('test.txt', 'w') as m_fo:
-            par.write_parameter(m_fo, "")
+            write_parameter(m_fo, parameter=par, stop_character="")
 
         expected_writes = [unittest.mock.call("double test"),
                            unittest.mock.call(""),
@@ -112,11 +112,11 @@ class Test_ParameterVariable(unittest.TestCase):
         is used. (float value)
         """
 
-        par = ParameterVariable("double", "test", value=5.4,
+        par = provide_parameter("double", "test", value=5.4,
                                 comment="test comment")
 
         with mock_f('test.txt', 'w') as m_fo:
-            par.write_parameter(m_fo, ")")
+            write_parameter(m_fo, parameter=par, stop_character=")")
 
         expected_writes = [unittest.mock.call("double test"),
                            unittest.mock.call(" = 5.4"),
@@ -138,11 +138,11 @@ class Test_ParameterVariable(unittest.TestCase):
         is used. (integer value)
         """
 
-        par = ParameterVariable("double", "test", value=5,
+        par = provide_parameter("double", "test", value=5,
                                 comment="test comment")
 
         with mock_f('test.txt', 'w') as m_fo:
-            par.write_parameter(m_fo, ")")
+            write_parameter(m_fo, parameter=par, stop_character=")")
 
         expected_writes = [unittest.mock.call("double test"),
                            unittest.mock.call(" = 5"),
@@ -164,11 +164,11 @@ class Test_ParameterVariable(unittest.TestCase):
         is used. (string value)
         """
 
-        par = ParameterVariable("double", "test", value="\"Al\"",
+        par = provide_parameter("double", "test", value="\"Al\"",
                                 comment="test comment")
 
         with mock_f('test.txt', 'w') as m_fo:
-            par.write_parameter(m_fo, ",")
+            write_parameter(m_fo, parameter=par, stop_character=",")
 
         expected_writes = [unittest.mock.call("double test"),
                            unittest.mock.call(" = \"Al\""),

--- a/mcstasscript/tests/test_widget_helpers.py
+++ b/mcstasscript/tests/test_widget_helpers.py
@@ -5,7 +5,7 @@ import io
 from mcstasscript.jb_interface.widget_helpers import HiddenPrints
 from mcstasscript.jb_interface.widget_helpers import parameter_has_default
 from mcstasscript.jb_interface.widget_helpers import get_parameter_default
-from mcstasscript.helper.mcstas_objects import ParameterVariable
+from mcstasscript.helper.mcstas_objects import provide_parameter
 
 
 class TestWidgetHelpers(unittest.TestCase):
@@ -35,7 +35,7 @@ class TestWidgetHelpers(unittest.TestCase):
         Check for parameter that does not have default, should be false
         """
 
-        par = ParameterVariable("test")
+        par = provide_parameter("test")
         self.assertFalse(parameter_has_default(par))
 
     def test_parameter_has_default_true(self):
@@ -43,7 +43,7 @@ class TestWidgetHelpers(unittest.TestCase):
         Check for parameter that has default, should be true
         """
 
-        par = ParameterVariable("test", value=8)
+        par = provide_parameter("test", value=8)
         self.assertTrue(parameter_has_default(par))
 
     def test_get_parameter_default_string(self):
@@ -51,7 +51,7 @@ class TestWidgetHelpers(unittest.TestCase):
         Get the default for string parameter
         """
 
-        par = ParameterVariable("string", "test", value="variable")
+        par = provide_parameter("string", "test", value="variable")
         self.assertEqual(get_parameter_default(par), "variable")
 
     def test_get_parameter_default_double_specified(self):
@@ -59,7 +59,7 @@ class TestWidgetHelpers(unittest.TestCase):
         Get the default for specified double parameter
         """
 
-        par = ParameterVariable("double", "test", value=5.5)
+        par = provide_parameter("double", "test", value=5.5)
         self.assertEqual(get_parameter_default(par), 5.5)
 
     def test_get_parameter_default_double(self):
@@ -67,7 +67,7 @@ class TestWidgetHelpers(unittest.TestCase):
         Get the default for parameter that was double by default
         """
 
-        par = ParameterVariable("test", value=5.7)
+        par = provide_parameter("test", value=5.7)
         self.assertEqual(get_parameter_default(par), 5.7)
 
     def test_get_parameter_default_int(self):
@@ -75,7 +75,7 @@ class TestWidgetHelpers(unittest.TestCase):
         Get default value from integer value, should be rounded
         """
 
-        par = ParameterVariable("int", "test", value=5.7)
+        par = provide_parameter("int", "test", value=5.7)
         self.assertEqual(get_parameter_default(par), 5)
 
 


### PR DESCRIPTION
Changes to how parameters work in McStasScript to allow libpyvinyl parameter objects to control parameters inside a McStasScript instrument from the outside.

The restructure maintains the current syntax, but now uses libpyvinyl objects for Parameter and CalculatorParameters directly instead of its own classes that inherited from those. The extra functionality needed in McStasScript is now provided by a function that take Parameter as an input, along with adding one extra attribute to Parameter on import.

Unit tests and doc strings have been updated. No changes necessary to the documentation. 