### PR TITLE
Using base_dir from BaseCalculator

### DIFF
--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -364,9 +364,6 @@ class McCode_instr(BaseCalculator):
         self.component_class_lib = {}
         self.widget_interface = None
 
-        # Ensure output_path field exist (not ensured by BaseCalculator)
-        if not hasattr(self, "output_path"):
-            self.output_path = self.name + "_data"
 
         # Avoid initializing if loading from dump
         if not hasattr(self, "declare_list"):
@@ -380,6 +377,14 @@ class McCode_instr(BaseCalculator):
             # Handle components
             self.component_list = []  # List of components (have to be ordered)
             self.component_name_list = []  # List of component names
+
+    @property
+    def output_path(self) -> str:
+        return self.base_dir
+
+    @output_path.setter
+    def output_path(self, value: str) -> None:
+        self.calculator_base_dir = value
 
     def init_parameters(self):
         """


### PR DESCRIPTION
McStasscript uses the value of the output_path member to put the output of the calculations.
In `libpyvinyl` the BaseCalculator, from which the McStas_instr inherits, has a base_dir method that returns the output path as a combination of the instrument_base_dir and the calculator_base_dir.

Changing output_path from member of the McStas_instr class to method, and returning the base_dir solves the issue and keeps backward compatibility