### PR TITLE
method to allow adding an additional directory to find components

### DIFF
--- a/mcstasscript/helper/component_reader.py
+++ b/mcstasscript/helper/component_reader.py
@@ -170,6 +170,55 @@ class ComponentReader:
 
             print("These definitions will be used instead of the installed "
                   + "versions.")
+    def add_custom_component_dir(self, input_path=".", category="custom"):
+        """
+        Method to add further directories containing custom components
+        """
+        # Will overwrite McStas components with definitions in input_folder
+        current_directory = os.getcwd()
+
+        # Set up absolute input_path
+        if os.path.isabs(input_path):
+            input_directory = input_path
+        else:
+            if input_path == ".":
+                # Default case, avoid having /./ in absolute path
+                input_directory = current_directory
+            else:
+                input_directory = os.path.join(current_directory, input_path)
+
+        if not os.path.isdir(input_directory):
+            print("input_path: ", input_directory)
+            raise ValueError("Can't find given input_path," + " directory must exist.")
+        """
+        If components are present both in the McStas install and the
+        work directory, the version in the work directory is used. The user
+        is informed of this behavior when the instrument object is created.
+        """
+        overwritten_components = []
+        for file in os.listdir(input_directory):
+            if file.endswith(".comp"):
+                abs_path = os.path.join(input_directory, file)
+                component_name = os.path.split(abs_path)[1].split(".")[-2]
+
+                if component_name in self.component_path:
+                    overwritten_components.append(file)
+
+                self.component_path[component_name] = abs_path
+                self.component_category[component_name] = category
+
+        # Report components found in the work directory and install to the user
+        if len(overwritten_components) > 0:
+            print(
+                "The following components are found in the work_directory"
+                + " / input_path:"
+            )
+            for name in overwritten_components:
+                print("    ", name)
+
+            print(
+                "These definitions will be used instead of the installed " + "versions."
+            )
 
     def show_categories(self):
         """

--- a/mcstasscript/helper/managed_mcrun.py
+++ b/mcstasscript/helper/managed_mcrun.py
@@ -83,7 +83,7 @@ class ManagedMcrun:
                 If True, automatically appends output_path to make it unique
             force_compile : bool, default True
                 If True, forces compile. If False no new instrument is written
-            run_folder : str
+            run_path : str
                 Path to folder in which to run McStas
             openacc : bool, default False
                 If True, adds the --openacc flag to mcrun call

--- a/mcstasscript/helper/managed_mcrun.py
+++ b/mcstasscript/helper/managed_mcrun.py
@@ -89,11 +89,14 @@ class ManagedMcrun:
                 If True, adds the --openacc flag to mcrun call
             NeXus : bool, default False
                 If True, adds the --format=NeXus to mcrun call
+           component_dirs: list
+                Sets non standard paths to search for component definitions
 
         """
 
         self.name_of_instrumentfile = instr_name
 
+        self.component_dirs=[]
         self.data_folder_name = ""
         self.ncount = int(1E6)
         self.mpi = None
@@ -109,6 +112,9 @@ class ManagedMcrun:
         self.run_path = "."
         self.seed = None
         self.suppress_output = False
+
+        if "component_dirs" in kwargs:
+            self.component_dirs = kwargs["component_dirs"]
 
         # executable_path always in kwargs
         if "executable_path" in kwargs:
@@ -279,10 +285,15 @@ class ManagedMcrun:
                                                self.executable)
         mcrun_full_path = '"' + mcrun_full_path + '"' # Path in quotes to allow spaces
 
+        add_component_dirs=""
+        for d in self.component_dirs:
+            add_component_dirs="-I "+d
+
         # Run the mcrun command on the system
         full_command = (mcrun_full_path + " "
                         + option_string + " "
                         + self.custom_flags + " "
+                        + add_component_dirs + " "
                         + self.name_of_instrumentfile
                         + parameter_string)
 

--- a/mcstasscript/helper/mcstas_objects.py
+++ b/mcstasscript/helper/mcstas_objects.py
@@ -159,8 +159,8 @@ def write_parameter(fo, parameter, stop_character):
     else:
         fo.write(parameter.name)
 
-    if parameter.unit != 'dimensionless':
-        fo.write(f'("{parameter.unit}")')
+    #if parameter.unit != 'dimensionless':
+    #    fo.write(f'("{parameter.unit}")')
 
     if parameter.value is not None:
         if isinstance(parameter.value, int):

--- a/mcstasscript/instrument_diagnostics/beam_diagnostics.py
+++ b/mcstasscript/instrument_diagnostics/beam_diagnostics.py
@@ -413,5 +413,5 @@ class BeamDiagnostics(DiagnosticsInstrument):
                 print("No data to plot! Use the run method to generate data.")
 
         overview = PlotOverview(self.event_plotters, self.views)
-        overview.plot_all()
+        return overview.plot_all()
 

--- a/mcstasscript/instrument_diagnostics/event_plotter.py
+++ b/mcstasscript/instrument_diagnostics/event_plotter.py
@@ -73,7 +73,7 @@ class EventPlotter:
             View for which limits should be retrieved
         """
         if view.axis2 is None:
-            return np.NaN, np.NaN
+            return np.nan, np.nan
         data = self.data.get_data_column(view.axis2, flag_info=self.flag_info)
         return np.min(data), np.max(data)
 
@@ -128,4 +128,3 @@ class EventPlotter:
 
             ax.set_xlim(x_lims)
             ax.set_ylim(y_lims)
-

--- a/mcstasscript/instrument_diagnostics/plot_overview.py
+++ b/mcstasscript/instrument_diagnostics/plot_overview.py
@@ -62,6 +62,7 @@ class PlotOverview:
                 major_label_set = True
 
         fig.tight_layout()
+        return fig
 
     def set_same_scale(self):
         """

--- a/mcstasscript/instrument_diagram/canvas.py
+++ b/mcstasscript/instrument_diagram/canvas.py
@@ -456,3 +456,5 @@ class DiagramCanvas:
 
         # Show the figure
         plt.show()
+
+        return fig

--- a/mcstasscript/instrument_diagram/make_diagram.py
+++ b/mcstasscript/instrument_diagram/make_diagram.py
@@ -91,4 +91,5 @@ def instrument_diagram(instrument, analysis=False, variable=None, limits=None):
                            limits=limits)
 
     # Plot diagram
-    canvas.plot()
+    return canvas.plot()
+    

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -2825,15 +2825,17 @@ class McCode_instr(BaseCalculator):
         if variable is not None:
             analysis = True
 
-        instrument_diagram(self, analysis=analysis, variable=variable, limits=limits)
+        fig = instrument_diagram(self, analysis=analysis, variable=variable, limits=limits)
 
         if self._run_settings["checks"]:
             self.check_for_errors()
 
+        return fig
+
     def show_analysis(self, variable=None):
         beam_diag = IntensityDiagnostics(self)
         beam_diag.run_general(variable=variable)
-        beam_diag.plot()
+        return beam_diag.plot()
 
     def saveH5(self, filename: str, openpmd: bool = True):
         """

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -151,6 +151,9 @@ class McCode_instr(BaseCalculator):
     component_help(name)
         Shows help on component of given name
 
+    add_component_dir(path)
+        Add path to the search dir for components
+
     add_component(instance_name, component_name, **kwargs)
         Add a component to the instrument file
 
@@ -346,6 +349,8 @@ class McCode_instr(BaseCalculator):
                 parameter.type = None
 
         self._run_settings = {}  # Settings for running simulation
+
+        self._run_settings["component_dirs"] = []
 
         # Sets max_line_length and adds paths to run_settings
         self._read_calibration()
@@ -948,7 +953,7 @@ class McCode_instr(BaseCalculator):
         if declare_par.name in names:
             raise NameError("Variable with name '" + declare_par.name
                             + "' already present in instrument!")
-        
+
         self.declare_list.append(declare_par)
         return declare_par
 
@@ -1203,6 +1208,19 @@ class McCode_instr(BaseCalculator):
 
         return self.component_class_lib[component_name](name, component_name,
                                                         **kwargs)
+
+    def add_component_dir(self, path=".", category="custom"):
+        """
+        Method for adding a directory to the list of directories where to search for components"
+        """
+        self.component_reader.add_custom_component_dir(path, category)
+
+        current_directory = os.getcwd()
+
+        if not os.path.isabs(path):
+            path = os.path.join(current_directory, path)
+
+        self._run_settings["component_dirs"].append(path)
 
     def add_component(self, name, component_name=None, *, before=None,
                       after=None, AT=None, AT_RELATIVE=None, ROTATED=None,
@@ -2325,7 +2343,7 @@ class McCode_instr(BaseCalculator):
                  increment_folder_name=None, custom_flags=None,
                  executable=None, executable_path=None,
                  suppress_output=None, gravity=None, checks=None,
-                 openacc=None, NeXus=None, save_comp_pars=False):
+                 openacc=None, NeXus=None, save_comp_pars=False, component_dirs=None, run_path=None):
         """
         Sets settings for McStas run performed with backengine
 
@@ -2364,6 +2382,10 @@ class McCode_instr(BaseCalculator):
                 If True, adds --format=NeXus to mcrun call
             save_comp_pars : bool
                 If True, McStas run writes all comp pars to disk
+            component_dirs : list
+                Additional directories where to find components (use absolute paths)
+            run_path : str
+                Change the directory where the code is compiled and run
         """
 
         settings = {}
@@ -2427,6 +2449,11 @@ class McCode_instr(BaseCalculator):
 
         if save_comp_pars is not None:
             settings["save_comp_pars"] = bool(save_comp_pars)
+
+        if len(component_dirs) > 0:
+            settings["component_dirs"] = component_dirs
+        else:
+            settings["component_dirs"] = []
 
         self._run_settings.update(settings)
 
@@ -2551,7 +2578,7 @@ class McCode_instr(BaseCalculator):
         # Load data and store in __data
         #data = simulation.load_results()
         #self._set_data(data)
-        
+
         ## look for MCPL_output components and the defined filenames
         self.__add_mcpl_to_output(simulation)
 
@@ -2560,7 +2587,7 @@ class McCode_instr(BaseCalculator):
         data_dict = {"data": data}
         # adding to the libpyvinyl output datacollection with key = sim_data_key
         sim_data_key = self.output_keys[0]
-        output_data = self.output[sim_data_key] 
+        output_data = self.output[sim_data_key]
         output_data.set_dict(data_dict)
 
         if self.run_to_ref is not None:
@@ -2613,7 +2640,7 @@ class McCode_instr(BaseCalculator):
                     mcpl_file.key = mcpl_file+str(num_mcpl_files)
                 self.output.add_data(mcpl_file)
                 self.output_keys.append(mcpl_file.key)
-        
+
     def run_full_instrument(self, **kwargs):
         """
         Runs McStas instrument described by this class, returns list of

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -8,6 +8,8 @@ import subprocess
 import copy
 import warnings
 import re
+import io
+import hashlib
 
 from IPython.display import IFrame
 
@@ -2056,7 +2058,15 @@ class McCode_instr(BaseCalculator):
                 full_line = line_number + line
                 print(full_line.replace("\n", ""))
 
-    def write_full_instrument(self):
+
+    def __hash__(self):
+        """ Define a hashing specifically for this calculator
+        The hash method in the BaseCalculator would pack also the internals of this class and it changes when calling the backengine
+        """
+        contents = self.write_full_instrument(False)
+        return int.from_bytes(hashlib.sha256(contents.encode()).digest(), "big")
+
+    def write_full_instrument(self, do_write=True) -> str:
         """
         Method for writing full instrument file to disk
 
@@ -2070,8 +2080,12 @@ class McCode_instr(BaseCalculator):
             self.check_for_errors()
 
         # Create file identifier
-        fo = open(os.path.join(self.input_path, self.name + ".instr"), "w")
-
+        run_path = self._run_settings["run_path"]
+        fo = None
+        if do_write:
+            fo = open(os.path.join(run_path, self.name + ".instr"), "w")
+        else:
+            fo = io.StringIO()
         # Write quick doc start
         fo.write("/" + 80*"*" + "\n")
         fo.write("* \n")
@@ -2091,7 +2105,8 @@ class McCode_instr(BaseCalculator):
         fo.write("* %Identification\n")  # Could allow the user to insert this
         fo.write("* Written by: %s\n" % self.author)
         t_format = "%H:%M:%S on %B %d, %Y"
-        fo.write("* Date: %s\n" % datetime.datetime.now().strftime(t_format))
+        if do_write:
+            fo.write("* Date: %s\n" % datetime.datetime.now().strftime(t_format))
         fo.write("* Origin: %s\n" % self.origin)
         fo.write("* %INSTRUMENT_SITE: Generated_instruments\n")
         fo.write("* \n")
@@ -2114,14 +2129,18 @@ class McCode_instr(BaseCalculator):
         fo.write("\n")
         fo.write("DEFINE INSTRUMENT %s (" % self.name)
         fo.write("\n")
-        # Insert parameters
-        parameter_list = list(self.parameters)
-        end_chars = [", "]*len(parameter_list)
-        if len(end_chars) >= 1:
-            end_chars[-1] = " "
-        for variable, end_char in zip(parameter_list, end_chars):
-            write_parameter(fo, variable, end_char)
-        fo.write(")\n")
+
+        # remove parameters when calculating hash because don't want
+        # variations in the parameter values to trigger a new hash
+        if do_write:
+            # Insert parameters
+            parameter_list = list(self.parameters)
+            end_chars = [", "]*len(parameter_list)
+            if len(end_chars) >= 1:
+                end_chars[-1] = " "
+            for variable, end_char in zip(parameter_list, end_chars):
+                write_parameter(fo, variable, end_char)
+            fo.write(")\n")
         if self.dependency_statement != "":
             fo.write("DEPENDENCY " + str(self.dependency_statement) + "\n")
         fo.write("\n")
@@ -2190,7 +2209,11 @@ class McCode_instr(BaseCalculator):
         # End instrument file
         fo.write("\nEND\n")
 
+        instrument_file_as_string = ""
+        if do_write is False:
+            instrument_file_as_string = fo.getvalue()
         fo.close()
+        return instrument_file_as_string
 
     def get_component_subset_index_range(self, start_ref=None, end_ref=None):
         """
@@ -2450,10 +2473,14 @@ class McCode_instr(BaseCalculator):
         if save_comp_pars is not None:
             settings["save_comp_pars"] = bool(save_comp_pars)
 
-        if len(component_dirs) > 0:
-            settings["component_dirs"] = component_dirs
-        else:
-            settings["component_dirs"] = []
+        if component_dirs is not None:
+            if len(component_dirs) > 0:
+                settings["component_dirs"].append( component_dirs)
+            else:
+                settings["component_dirs"] = []
+
+        if run_path is not None:
+            settings["run_path"] = os.path.abspath(run_path)
 
         self._run_settings.update(settings)
 
@@ -2554,7 +2581,11 @@ class McCode_instr(BaseCalculator):
         self.__add_input_to_mcpl()
 
         instrument_path = os.path.join(self.input_path, self.name + ".instr")
+
+        run_path = self._run_settings["run_path"]
+        instrument_path = os.path.join(run_path, self.name + ".instr")
         if not os.path.exists(instrument_path) or self._run_settings["force_compile"]:
+            print("Instrument file not found: ", instrument_path, os.path.exists(instrument_path), self._run_settings["force_compile"])
             self.write_full_instrument()
 
         parameters = {}
@@ -2570,7 +2601,7 @@ class McCode_instr(BaseCalculator):
         options["output_path"] = self.output_path
 
         # Set up the simulation
-        simulation = ManagedMcrun(self.name + ".instr", **options)
+        simulation = ManagedMcrun(instrument_path, **options) #self.name + ".instr", **options)
 
         # Run the simulation and return data
         simulation.run_simulation()


### PR DESCRIPTION
By default components are looked for in the current working directory or the standard McStas folders. When using the instrument database, it is necessary to place components in several special folders. This method is currently used in the description of the ThALES instrument (prototype).