### PR TITLE
Using libpyvinyl input and output for transferring MCPL from one instrument to another

### DIFF
--- a/mcstasscript/data/MCPLDataFormat.py
+++ b/mcstasscript/data/MCPLDataFormat.py
@@ -1,0 +1,36 @@
+from libpyvinyl.BaseFormat import BaseFormat
+from mcstasscript.helper.managed_mcrun import load_results
+
+
+class MCPLDataFormat(BaseFormat):
+    def __init__(self) -> None:
+        super().__init__()
+
+    @classmethod
+    def format_register(self):
+        key = "mcpl"
+        desciption = "MCPL file"
+        file_extension = ".mcpl"
+        read_kwargs = [""]
+        write_kwargs = [""]
+        return self._create_format_register(
+            key, desciption, file_extension, read_kwargs, write_kwargs
+        )
+
+    @staticmethod
+    def direct_convert_formats():
+        # Assume the format can be converted directly to the formats supported by these classes:
+        # AFormat, BFormat
+        # Redefine this `direct_convert_formats` for a concrete format class
+        return []
+
+    @classmethod
+    def read(cls, filename: str) -> dict:
+        """Read the data from the file with the `filename` to a dictionary. The dictionary will
+        be used by its corresponding data class."""
+        raise NotImplemented("Read method for MCPL is not implemented nor required")
+
+    @classmethod
+    def write(cls, object, filename: str, key: str = None):
+        """Don't have a way to write McStasData"""
+        raise NotImplemented("Write method for MCPL is not implemented nor required")

--- a/mcstasscript/data/pyvinylData.py
+++ b/mcstasscript/data/pyvinylData.py
@@ -1,5 +1,6 @@
 from libpyvinyl.BaseData import BaseData
 from mcstasscript.data.McStasDataFormat import McStasFormat
+from mcstasscript.data.MCPLDataFormat import MCPLDataFormat
 
 
 class pyvinylMcStasData(BaseData):
@@ -49,3 +50,27 @@ class pyvinylMcStasData(BaseData):
     def from_dict(cls, data_dict, key):
         """Create the data class by a python dictionary."""
         return cls(key, data_dict=data_dict)
+
+
+class pyvinylMCPLData(BaseData):
+    def __init__(
+        self,
+        key,
+        data_dict=None,
+        # the filename can be assigned later.
+        # If filename == "" or None it fails the consistency check of BaseData
+        filename="none",
+        file_format_class=None,
+        file_format_kwargs=None,
+    ):
+        expected_data = {}
+        super().__init__(key, expected_data, None, filename, MCPLDataFormat, None)
+
+    def supported_formats(self):
+        format_dict = {}
+        self._add_ioformat(format_dict, MCPLDataFormat)
+        return format_dict
+
+    @classmethod
+    def from_file(cls, filename: str, key="mcpl"):
+        return cls(key, filename=filename)

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -292,7 +292,7 @@ class McCode_instr(BaseCalculator):
         """
 
         super().__init__(name, input=[],
-                         output_keys=["simulation_data"],
+                         output_keys=[name + "_data"],
                          output_data_types=[pyvinylMcStasData],
                          parameters=parameters)
 

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -2321,7 +2321,7 @@ class McCode_instr(BaseCalculator):
         method.
         """
 
-        self.add_input_to_mcpl()
+        self.__add_input_to_mcpl()
 
         instrument_path = os.path.join(self.input_path, self.name + ".instr")
         if not os.path.exists(instrument_path) or self._run_settings["force_compile"]:
@@ -2350,7 +2350,7 @@ class McCode_instr(BaseCalculator):
         #self._set_data(data)
         
         ## look for MCPL_output components and the defined filenames
-        self.add_mcpl_to_output(simulation)
+        self.__add_mcpl_to_output(simulation)
 
         # simulation results from .dat files loaded as dict
         data = simulation.load_results()
@@ -2381,7 +2381,7 @@ class McCode_instr(BaseCalculator):
         else:
             return self.output[sim_data_key].get_data()["data"]
 
-    def add_input_to_mcpl(self):
+    def __add_input_to_mcpl(self):
         try:
             mcpl_file = self.input["mcpl"].filename
             for comp in self.component_list:
@@ -2391,7 +2391,7 @@ class McCode_instr(BaseCalculator):
         except:
             return
 
-    def add_mcpl_to_output(self, managed_mcrun):
+    def __add_mcpl_to_output(self, managed_mcrun):
         MCPL_extension = MCPLDataFormat.format_register()["ext"]
         num_mcpl_files = 0
         for comp in self.component_list[::-1]: # starting from the last one!


### PR DESCRIPTION
 - A new `MCPLDataFormat` is defined to keep the path of an MCPL file.
 - A corresponding `pyvinylMCPLData` data class is defined
 - When calling the backengine, before writing the instrument file to disk, if an entry in the input DataCollection with key "mcpl" is found, the mcpl filename is replacing the filename value in any MCPL_input component found
 - If MCPL_output components are defined, the absolute path of the files is added to the output DataCollection with key "mcpl", "mcpl2", etc. starting from the last MCPL_output component defined.