### PR TITLE
[Refactor] First-run and re-configuration directories

### DIFF
--- a/mcstasscript/configuration.yaml
+++ b/mcstasscript/configuration.yaml
@@ -1,7 +1,0 @@
-other:
-  characters_per_line: 85
-paths:
-  mcrun_path: /Applications/McStas-2.7.1.app/Contents/Resources/mcstas/2.7.1/bin/
-  mcstas_path: /Applications/McStas-2.7.1.app/Contents/Resources/mcstas/2.7.1/
-  mcxtrace_path: /Applications/McXtrace-1.5.app/Contents/Resources/mcxtrace/1.5/
-  mxrun_path: /Applications/McXtrace-1.5.app/Contents/Resources/mcxtrace/1.5/bin/


### PR DESCRIPTION
- The (re)configuration process uses default directories which are only appropriate for one version of McStas and McXtrace on a macOS system. For all other systems, as a first step a user *must* create an appropriate configuration file to use McStasScript.
- This commit adds the 'default' paths specified in the McStasScript documentation for Windows, Linux, and MacOS systems and choosed between them based on the current system platform. It then attempts to find the respective binary locations for McStas and McXtrace and uses their locations, if found, in place of the default paths.
- If McStasScript is installed into a non-user-writable directory, this method will fail as there is no way to create the first configuration file. Instead the configuration.yaml should be written into the home directory, possibly via the [confuse](https://pypi.org/project/confuse/) library.