### PR TITLE
A few notebook edits for compatibility with McStas 3.x

### DIFF
--- a/examples/McStasScript_demo.ipynb
+++ b/examples/McStasScript_demo.ipynb
@@ -709,9 +709,9 @@
    "outputs": [],
    "source": [
     "# Adjusting PSD_4PI plot\n",
-    "functions.name_plot_options(\"PSD_4PI\", data, log=1, colormap=\"hot\", orders_of_mag=5)\n",
+    "ms.name_plot_options(\"PSD_4PI\", data, log=1, colormap=\"hot\", orders_of_mag=5)\n",
     "\n",
-    "plot = plotter.make_sub_plot(data) # Making subplot of our monitors"
+    "plot = ms.make_sub_plot(data) # Making subplot of our monitors"
    ]
   }
  ],

--- a/examples/calibration_sample.ipynb
+++ b/examples/calibration_sample.ipynb
@@ -26,6 +26,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add Union_init for McStas 3.x support\n",
+    "Init = instr.add_component(\"init\", \"Union_init\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -291,6 +301,18 @@
     "EPSD = instr.add_component(\"EPSD\", \"EPSD_monitor\", RELATIVE=PSD)\n",
     "EPSD.set_parameters(filename='\"EPSD.dat\"', xwidth=0.1, yheight=0.02, nE=300, nx=200, restore_neutron=1,\n",
     "                    Emin=\"energy - delta_energy\", Emax=\"energy + delta_energy\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Add Union_stop for McStas 3.x support\n",
+    "Stop = instr.add_component(\"stop\", \"Union_stop\")"
    ]
   },
   {

--- a/examples/calibration_sample.ipynb
+++ b/examples/calibration_sample.ipynb
@@ -277,8 +277,8 @@
    "outputs": [],
    "source": [
     "# Adds 1D position sensitive detector for transmission measurement\n",
-    "PSD = instr.add_component(\"PSDlin\", \"PSDlin_monitor\", AT=[0,0,1], RELATIVE=sample_pos) \n",
-    "PSD.set_parameters(filename='\"PSDlin.dat\"', xwidth=0.1, yheight=0.1, nx=200, restore_neutron=1)"
+    "PSDlin = instr.add_component(\"PSDlin\", \"PSDlin_monitor\", AT=[0,0,1], RELATIVE=sample_pos) \n",
+    "PSDlin.set_parameters(filename='\"PSDlin.dat\"', xwidth=0.1, yheight=0.1, nbins=200, restore_neutron=1)"
    ]
   },
   {

--- a/examples/libpyvinyl_example.ipynb
+++ b/examples/libpyvinyl_example.ipynb
@@ -196,10 +196,10 @@
    "source": [
     "mon.xwidth = 0.2\n",
     "mon.yheight = 0.2\n",
-    "mon.maxdiv_h = 30.0\n",
+    "mon.maxdiv = 30.0\n",
     "mon.filename = '\"acceptance_h.dat\"'\n",
     "mon.restore_neutron = 1\n",
-    "mon.nh = 300\n",
+    "mon.nb = 300\n",
     "mon.ndiv = 300\n",
     "mon.set_AT(0.1, RELATIVE=sample)"
    ]

--- a/examples/libpyvinyl_example.ipynb
+++ b/examples/libpyvinyl_example.ipynb
@@ -294,7 +294,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calculator.output[\"simulation_data\"].get_data()[\"data\"]"
+    "calculator.output.get_data()[\"data\"]"
    ]
   },
   {

--- a/examples/random_demonstration.py
+++ b/examples/random_demonstration.py
@@ -11,6 +11,9 @@ instr = ms.McStas_instr("random_demo",
 
 # Set up a material called Cu with approrpiate properties
 # (uses McStas Union components, here the processes)
+
+Init = instr.add_component("init", "Union_init")
+
 Cu_inc = instr.add_component("Cu_incoherent", "Incoherent_process")
 Cu_inc.sigma = 4*0.55
 Cu_inc.packing_factor = 1
@@ -117,6 +120,8 @@ big_PSD.nx = 500
 big_PSD.ny = 500
 big_PSD.filename = '"big_PSD.dat"'
 big_PSD.restore_neutron = 1
+
+Stop = instr.add_component("stop", "Union_stop")
 
 instr.show_components()
 


### PR DESCRIPTION
By no means complete, but means that some of the example notebooks will more likely run with a McStas 3.x.

During my work with the current McStasScript and McStas 3.3 in jupyterlab I further ran into an issue with notebooks containing `%matplotlib widget` syntax. A solution seemed to be to 

`pip3 install --upgrade jupyterlab ipympl`

Should we consider adding these as dependencies?