### PR TITLE
Allow McXtrace sessions to visualize using mxdisplay(-webgl/-pyqtgraph)

### DIFF
--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -2641,10 +2641,15 @@ class McCode_instr(BaseCalculator):
                                 + "="
                                 + str(val))  # parameter value
 
+        if self.package_name == "McXtrace":
+            executable = "mxdisplay"
+        else:
+            executable = "mxdisplay"
+
         if format == "webgl":
-            executable = "mcdisplay-webgl"
+            executable = executable+"-webgl"
         elif format == "window":
-            executable = "mcdisplay"
+            executable = executable+"-pyqtgraph"
 
         # Platform dependent, check both package_path and bin
         executable_path = self._run_settings["executable_path"]


### PR DESCRIPTION
I noticed that McXtrace-sessions did not allow instr-visualisation as the hard-coded `mcdisplay` command was used.

This patch includes a simple switch to use `mxdisplay` if we are running McXtrace.