### PR TITLE
Update my_configurator in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ After installation it is necessary to configure the package so the McStas/McXtra
     import mcstasscript as ms
     my_configurator = ms.Configurator()
     my_configurator.set_mcrun_path("/usr/bin/")
-    my_configurator.set_mcstas_path("/usr/share/mcstas/2.5/")
+    my_configurator.set_mcstas_path("/usr/share/mcstas/resources/")
     my_configurator.set_mxrun_path("/usr/bin/")
     my_configurator.set_mcxtrace_path("/usr/share/mcxtrace/1.5/")
 


### PR DESCRIPTION
Updated my_configurator in ubuntu to reflect the changes in naming made with mcstas 3.5.1. 

The change should probably made to the other configurators, but I don't have any other system than ubuntu, so I don't know the correct path.