### PR TITLE
Prototype of overwriting set_parameters from libpyvinyl for better help

### DIFF
--- a/mcstasscript/helper/mcstas_objects.py
+++ b/mcstasscript/helper/mcstas_objects.py
@@ -3,6 +3,7 @@ from mcstasscript.helper.formatting import is_legal_parameter
 from mcstasscript.helper.exceptions import McStasError
 from mcstasscript.helper.name_inspector import find_python_variable_name
 from mcstasscript.helper.search_statement import SearchStatement, SearchStatementList
+from mcstasscript.helper.signature_set_parameters import SetParametersCallableIComponent
 
 from libpyvinyl.Parameters.Parameter import Parameter
 
@@ -591,6 +592,9 @@ class Component:
         self.search_statement_list = SearchStatementList()
         self.save_parameters = save_parameters
 
+        # Provides help for set_parameters when used in jupyter notebooks
+        self.set_parameters = SetParametersCallableIComponent(self)
+
         # references to component names
         self.AT_reference = None
         self.ROTATED_reference = None
@@ -840,37 +844,8 @@ class Component:
             self.ROTATED_relative = "RELATIVE " + relative
             self.ROTATED_reference = relative
 
-    def set_parameters(self, args_as_dict=None, **kwargs):
-        """
-        Set Component parameters from dictionary input or keyword arguments
-
-        Relies on attributes added when McCode_Instr creates a subclass from
-        the Component class where each component parameter is added as an
-        attribute.
-
-        An error is raised if trying to set a parameter that does not exist
-
-        Parameters
-        ----------
-        args_as_dict : dict
-            Parameters names and their values as dictionary
-        """
-        if args_as_dict is not None:
-            parameter_dict = args_as_dict
-        else:
-            parameter_dict = kwargs
-
-        for key, val in parameter_dict.items():
-            if not hasattr(self, key):
-                raise NameError("No parameter called "
-                                + key
-                                + " in component named "
-                                + self.name
-                                + " of component type "
-                                + self.component_name
-                                + ".")
-            else:
-                setattr(self, key, val)
+    def get_parameter_names(self):
+        return self.parameter_names
 
     def set_WHEN(self, string):
         """

--- a/mcstasscript/helper/signature_set_parameters.py
+++ b/mcstasscript/helper/signature_set_parameters.py
@@ -89,7 +89,7 @@ class SetParametersCallable:
                 lines.append("    Instrument parameter.")
 
             if type_name == "string":
-                lines.append(f"    Remember '{'"'}string_input{'"'}' format for literal strings")
+                lines.append(f"    Remember '\"string_input\"' format for literal strings")
 
         lines.extend([
             "",

--- a/mcstasscript/helper/signature_set_parameters.py
+++ b/mcstasscript/helper/signature_set_parameters.py
@@ -1,0 +1,102 @@
+import inspect
+from inspect import Signature, Parameter
+from typing import Any
+
+
+class SetParametersCallable:
+    """
+    Method that can overwrite set_parameters on instr object and provide help
+
+    Help is provided as docstring which is updated whenever add_parameters is
+    called, and signature which provide autocompletion in jupyter notebooks.
+    """
+    def __init__(self, owner):
+        self.owner = owner
+        self.refresh_docstring()
+
+    def __call__(self, args_as_dict=None, **kwargs: Any) -> None:
+        if args_as_dict is not None:
+            kwargs.update(args_as_dict)
+
+        allowed = set(self.owner.get_parameter_names())
+        unknown = set(kwargs) - allowed
+        if unknown:
+            raise KeyError(f"Unknown parameters: {sorted(unknown)}")
+
+        if args_as_dict is not None:
+            parameter_dict = args_as_dict
+        else:
+            parameter_dict = kwargs
+
+        for key, parameter_value in parameter_dict.items():
+            self.owner.parameters[key].value = parameter_value
+
+    @property
+    def __signature__(self):
+        params = [
+            Parameter(
+                "args_as_dict",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                default=None,
+            )
+        ]
+
+        for name in self.owner.get_parameter_names():
+            params.append(
+                Parameter(
+                    name,
+                    kind=Parameter.KEYWORD_ONLY,
+                    default=None,
+                )
+            )
+
+        return Signature(params, return_annotation=None)
+
+    def refresh_docstring(self):
+        self.__doc__ = self._make_docstring()
+
+    def _make_docstring(self):
+        lines = [
+            "Set instrument parameters.",
+            "",
+            "Parameters can be supplied either as keyword arguments or as a dictionary.",
+            "",
+            "Parameters",
+            "----------",
+            "args_as_dict : dict, optional",
+            "    Dictionary mapping parameter names to values.",
+        ]
+
+        current_parameters = self.owner.parameters.parameters.values()
+
+        if len(current_parameters) == 0:
+            lines.append("")
+            lines.append("This instrument current does not have any parameters, "
+                         "can be added with add_parameter method")
+
+        for parameter in current_parameters:
+            name = parameter.name
+            type_name = getattr(parameter, "type", "double")
+            description = getattr(parameter, "comment", "")
+            if type_name == "":
+                type_name = "float"
+
+            lines.append(f"{name} : {type_name}, optional")
+
+            if description:
+                lines.append(f"    {description}")
+            else:
+                lines.append("    Instrument parameter.")
+
+            if type_name == "string":
+                lines.append(f"    Remember '{'"'}string_input{'"'}' format for literal strings")
+
+        lines.extend([
+            "",
+            "Examples",
+            "--------",
+            ">>> instr.set_parameters(parameter_name=2.0)",
+            ">>> instr.set_parameters({'parameter_name': 2.0})",
+        ])
+
+        return "\n".join(lines)

--- a/mcstasscript/helper/signature_set_parameters.py
+++ b/mcstasscript/helper/signature_set_parameters.py
@@ -3,9 +3,9 @@ from inspect import Signature, Parameter
 from typing import Any
 
 
-class SetParametersCallable:
+class SetParametersCallableInstrument:
     """
-    Method that can overwrite set_parameters on instr object and provide help
+    Class that can overwrite set_parameters on instr object and provide help
 
     Help is provided as docstring which is updated whenever add_parameters is
     called, and signature which provide autocompletion in jupyter notebooks.
@@ -15,18 +15,21 @@ class SetParametersCallable:
         self.refresh_docstring()
 
     def __call__(self, args_as_dict=None, **kwargs: Any) -> None:
-        if args_as_dict is not None:
-            kwargs.update(args_as_dict)
-
-        allowed = set(self.owner.get_parameter_names())
-        unknown = set(kwargs) - allowed
-        if unknown:
-            raise KeyError(f"Unknown parameters: {sorted(unknown)}")
-
+        """
+        This method is called when set_parameters is used on the instrument
+        object, updates the parameters accordingly
+        """
+        parameter_dict = {}
         if args_as_dict is not None:
             parameter_dict = args_as_dict
-        else:
-            parameter_dict = kwargs
+
+        # Parameters specified both in arg_as_dict and kwarg use kwarg value
+        parameter_dict.update(kwargs)
+
+        allowed = set(self.owner.get_parameter_names())
+        unknown = set(parameter_dict) - allowed
+        if unknown:
+            raise KeyError(f"Unknown parameters: {sorted(unknown)}")
 
         for key, parameter_value in parameter_dict.items():
             self.owner.parameters[key].value = parameter_value
@@ -61,6 +64,8 @@ class SetParametersCallable:
             "",
             "Parameters can be supplied either as keyword arguments or as a dictionary.",
             "",
+            "The .show_parameters method shows all available parameters",
+            "",
             "Parameters",
             "----------",
             "args_as_dict : dict, optional",
@@ -71,7 +76,7 @@ class SetParametersCallable:
 
         if len(current_parameters) == 0:
             lines.append("")
-            lines.append("This instrument current does not have any parameters, "
+            lines.append("This instrument currently does not have any parameters, "
                          "can be added with add_parameter method")
 
         for parameter in current_parameters:

--- a/mcstasscript/helper/signature_set_parameters.py
+++ b/mcstasscript/helper/signature_set_parameters.py
@@ -21,7 +21,7 @@ class SetParametersCallableInstrument:
         """
         parameter_dict = {}
         if args_as_dict is not None:
-            parameter_dict = args_as_dict
+            parameter_dict = dict(args_as_dict)
 
         # Parameters specified both in arg_as_dict and kwarg use kwarg value
         parameter_dict.update(kwargs)
@@ -125,7 +125,7 @@ class SetParametersCallableIComponent:
         """
         parameter_dict = {}
         if args_as_dict is not None:
-            parameter_dict = args_as_dict
+            parameter_dict = dict(args_as_dict)
 
         # Parameters specified both in arg_as_dict and kwarg use kwarg value
         parameter_dict.update(kwargs)

--- a/mcstasscript/helper/signature_set_parameters.py
+++ b/mcstasscript/helper/signature_set_parameters.py
@@ -105,3 +105,129 @@ class SetParametersCallableInstrument:
         ])
 
         return "\n".join(lines)
+
+
+class SetParametersCallableIComponent:
+    """
+    Class that can overwrite set_parameters on component object and provide help
+
+    Help is provided as docstring which is updated whenever add_parameters is
+    called, and signature which provide autocompletion in jupyter notebooks.
+    """
+    def __init__(self, owner):
+        self.owner = owner
+        #self.__doc__ = self._make_docstring()
+
+    def __call__(self, args_as_dict=None, **kwargs: Any) -> None:
+        """
+        This method is called when set_parameters is used on the instrument
+        object, updates the parameters accordingly
+        """
+        parameter_dict = {}
+        if args_as_dict is not None:
+            parameter_dict = args_as_dict
+
+        # Parameters specified both in arg_as_dict and kwarg use kwarg value
+        parameter_dict.update(kwargs)
+
+        allowed = set(self.owner.get_parameter_names())
+        unknown = set(parameter_dict) - allowed
+        if unknown:
+            raise NameError(f"Unknown parameters: {sorted(unknown)}")
+
+        for key, parameter_value in parameter_dict.items():
+            setattr(self.owner, key, parameter_value)
+
+    @property
+    def __signature__(self):
+        params = [
+            Parameter(
+                "args_as_dict",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                default=None,
+            )
+        ]
+
+        for name in self.owner.get_parameter_names():
+            params.append(
+                Parameter(
+                    name,
+                    kind=Parameter.KEYWORD_ONLY,
+                    default=None,
+                )
+            )
+
+        return Signature(params, return_annotation=None)
+
+    def refresh_docstring(self):
+        self.__doc__ = self._make_docstring()
+
+    def _make_docstring(self):
+        lines = [
+            "Set component parameters.",
+            "",
+            "Parameters can be supplied either as keyword arguments or as a dictionary.",
+            "",
+            "The .show_parameters method shows all available parameters",
+            "",
+            "Parameters",
+            "----------",
+            "args_as_dict : dict, optional",
+            "    Dictionary mapping parameter names to values.",
+        ]
+
+        parameter_names = self.owner.get_parameter_names()
+
+        if len(parameter_names) == 0:
+            lines.append("")
+            lines.append("This component does not have any parameters")
+
+        for parameter_name in parameter_names:
+            type_name = self.owner.parameter_types[parameter_name]
+
+            if parameter_name in self.owner.parameter_comments:
+                description = self.owner.parameter_comments[parameter_name]
+            else:
+                description = ""
+
+            if parameter_name in self.owner.parameter_units:
+                unit = f'[{self.owner.parameter_units[parameter_name]}]'
+            else:
+                unit = ""
+
+            required = False
+            if parameter_name in self.owner.parameter_defaults:
+                if self.owner.parameter_defaults[parameter_name] is None:
+                    required = True
+                else:
+                    required = False
+            else:
+                required = True
+
+            if required:
+                optional_text = "needs to be set"
+            else:
+                optional_text = "optional"
+
+            if type_name == "":
+                type_name = "float"
+
+            lines.append(f"{parameter_name} : {unit}, {type_name}, {optional_text}")
+
+            if description:
+                lines.append(f"    {description}")
+            else:
+                lines.append("    Component parameter.")
+
+            if type_name == "string":
+                lines.append(f"    Remember '\"string_input\"' format for literal strings")
+
+        lines.extend([
+            "",
+            "Examples",
+            "--------",
+            ">>> comp.set_parameters(parameter_name=2.0)",
+            ">>> comp.set_parameters({'parameter_name': 2.0})",
+        ])
+
+        return "\n".join(lines)

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -33,6 +33,7 @@ from mcstasscript.helper.check_mccode_version import check_mcstas_major_version
 from mcstasscript.helper.check_mccode_version import check_mcxtrace_major_version
 from mcstasscript.helper.name_inspector import find_python_variable_name
 from mcstasscript.helper.search_statement import SearchStatement, SearchStatementList
+from mcstasscript.helper.signature_set_parameters import SetParametersCallable
 from mcstasscript.instrument_diagram.make_diagram import instrument_diagram
 from mcstasscript.instrument_diagnostics.intensity_diagnostics import IntensityDiagnostics
 
@@ -433,6 +434,9 @@ class McCode_instr(BaseCalculator):
         # Holds major version of underlying package
         self.mccode_version = None
 
+        # Overwrite set_parameters to version that can autocomplete
+        self.set_parameters = SetParametersCallable(self)
+
         # Avoid initializing if loading from dump
         if not hasattr(self, "declare_list"):
             self.declare_list = []
@@ -744,7 +748,13 @@ class McCode_instr(BaseCalculator):
 
         self.parameters.add(par)
 
+        # set_parameters will now need an updated docstring
+        self.set_parameters.refresh_docstring()
+
         return par
+
+    def get_parameter_names(self):
+        return [parameter.name for parameter in self.parameters.parameters.values()]
 
     def show_parameters(self, line_length=None):
         """
@@ -2842,6 +2852,33 @@ class McCode_instr(BaseCalculator):
         Not relevant, but required from BaseCalculator, will be removed
         """
         pass
+
+    def __patch_set_parameters_signature(self):
+        import inspect
+        simple_par_dict = {}
+
+        for key, value in self.parameters.parameters.items():
+            this_type = value.type
+            if this_type in ("double", ""):
+                simple_par_dict[key] = float
+            elif this_type == "int":
+                simple_par_dict[key] = int
+            elif this_type == "string":
+                simple_par_dict[key] = str
+
+        params = []
+
+        for name, annotation in simple_par_dict.items():
+            params.append(
+                inspect.Parameter(
+                    name=name,
+                    kind=inspect.Parameter.KEYWORD_ONLY,
+                    default=None,
+                    annotation=annotation
+                )
+            )
+
+        self.set_parameters.__signature__ = inspect.Signature(params)
 
 
 class McStas_instr(McCode_instr):

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -33,7 +33,7 @@ from mcstasscript.helper.check_mccode_version import check_mcstas_major_version
 from mcstasscript.helper.check_mccode_version import check_mcxtrace_major_version
 from mcstasscript.helper.name_inspector import find_python_variable_name
 from mcstasscript.helper.search_statement import SearchStatement, SearchStatementList
-from mcstasscript.helper.signature_set_parameters import SetParametersCallable
+from mcstasscript.helper.signature_set_parameters import SetParametersCallableInstrument
 from mcstasscript.instrument_diagram.make_diagram import instrument_diagram
 from mcstasscript.instrument_diagnostics.intensity_diagnostics import IntensityDiagnostics
 
@@ -435,7 +435,7 @@ class McCode_instr(BaseCalculator):
         self.mccode_version = None
 
         # Overwrite set_parameters to version that can autocomplete
-        self.set_parameters = SetParametersCallable(self)
+        self.set_parameters = SetParametersCallableInstrument(self)
 
         # Avoid initializing if loading from dump
         if not hasattr(self, "declare_list"):
@@ -2852,33 +2852,6 @@ class McCode_instr(BaseCalculator):
         Not relevant, but required from BaseCalculator, will be removed
         """
         pass
-
-    def __patch_set_parameters_signature(self):
-        import inspect
-        simple_par_dict = {}
-
-        for key, value in self.parameters.parameters.items():
-            this_type = value.type
-            if this_type in ("double", ""):
-                simple_par_dict[key] = float
-            elif this_type == "int":
-                simple_par_dict[key] = int
-            elif this_type == "string":
-                simple_par_dict[key] = str
-
-        params = []
-
-        for name, annotation in simple_par_dict.items():
-            params.append(
-                inspect.Parameter(
-                    name=name,
-                    kind=inspect.Parameter.KEYWORD_ONLY,
-                    default=None,
-                    annotation=annotation
-                )
-            )
-
-        self.set_parameters.__signature__ = inspect.Signature(params)
 
 
 class McStas_instr(McCode_instr):

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -1211,8 +1211,11 @@ class McCode_instr(BaseCalculator):
 
             self.component_class_lib[component_name] = dynamic_component_class
 
-        return self.component_class_lib[component_name](name, component_name,
-                                                        **kwargs)
+        out = self.component_class_lib[component_name](name, component_name,
+                                                       **kwargs)
+        out.set_parameters.refresh_docstring()
+
+        return out
 
     def add_component(self, name, component_name=None, *, before=None,
                       after=None, AT=None, AT_RELATIVE=None, ROTATED=None,

--- a/mcstasscript/tests/test_Instr.py
+++ b/mcstasscript/tests/test_Instr.py
@@ -18,9 +18,20 @@ from mcstasscript.helper.beam_dump_database import BeamDump
 
 run_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '.')
 
+
 class DummyComponent(Component):
     def __init__(self, *args, **kwargs):
+        self.parameter_names = ["filename", "test_keyword"]
+        self.parameter_defaults = {}
+        self.parameter_types = {'filename': 'string', 'test_keyword': 'double'}
+        self.parameter_units = {}
+        self.parameter_comments = {}
+        self.category = {}
+
+        self.test_keyword = None
+        self.filename = None
         super().__init__(*args, **kwargs)
+
 
     def set_parameters(self, *args, **kwargs):
         pass

--- a/mcstasscript/tests/test_component.py
+++ b/mcstasscript/tests/test_component.py
@@ -305,9 +305,14 @@ class TestComponent(unittest.TestCase):
 
         comp = Component("test_component", "Arm")
 
+
+
         # Need to add some parameters to this bare component
         # Parameters are usually added by McStas_Instr
         comp._unfreeze()
+
+        comp.parameter_names = ["new_par1", "new_par2", "this_par"]
+
         comp.new_par1 = 1
         comp.new_par2 = 3
         comp.this_par = 1492.2


### PR DESCRIPTION
The set_parameter method now returns the text below on help(instr.set_parameters), shows the same using shift+tab shortcut in jupyter notebooks and provides autocomplete for typing the keyword arguments in set_parameters.

Attempts to address #98 

```
Help on SetParametersCallable in module mcstasscript.helper.signature_set_parameters:

<mcstasscript.helper.signature_set_parameters.SetParametersCallable object>
    Set instrument parameters.

    Parameters can be supplied either as keyword arguments or as a dictionary.

    Parameters
    ----------
    args_as_dict : dict, optional
        Dictionary mapping parameter names to values.
    flux : float, optional
        Instrument parameter.
    wavelength : float, optional
        description
    delta_wavelength : float, optional
        Instrument parameter.
    string_par : string, optional
        Instrument parameter.
        Remember '"string_input"' format for literal strings

    Examples
    --------
    >>> instr.set_parameters(parameter_name=2.0)
    >>> instr.set_parameters({'parameter_name': 2.0})
```

