### PR TITLE
Allow McStasScript to support mpi='auto'

### DIFF
--- a/mcstasscript/helper/managed_mcrun.py
+++ b/mcstasscript/helper/managed_mcrun.py
@@ -140,13 +140,15 @@ class ManagedMcrun:
                 self.mpi = int(self.mpi)
             except (TypeError, ValueError) as e:
                 if self.mpi is not None:
-                    raise RuntimeError("MPI should be an integer, was "
-                                       + str(self.mpi))
+                    if not self.mpi == 'auto':
+                        raise RuntimeError("MPI should be an integer, was "
+                                        + str(self.mpi))
 
             if self.mpi is not None:
-                if self.mpi < 1:
-                    raise ValueError("MPI should be an integer larger than"
-                                     + " 0, was " + str(self.mpi))
+                if not self.mpi == 'auto':
+                    if self.mpi < 1:
+                        raise ValueError("MPI should be an integer larger than"
+                                        + " 0, was " + str(self.mpi))
 
         if "gravity" in kwargs:
             self.gravity = kwargs["gravity"]

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -2407,8 +2407,12 @@ class McCode_instr(BaseCalculator):
             settings["ncount"] = ncount
 
         if mpi != "not_set":  # None is a legal value for mpi
-            if not isinstance(mpi, (type(None), int)):
-                raise TypeError("mpi must be an integer or None.")
+            # check for special case of 'auto', as supported by mcrun
+            if mpi=='auto':
+                pass
+            else:
+                if not isinstance(mpi, (type(None), int)):
+                    raise TypeError("mpi must be an integer or None.")
             settings["mpi"] = mpi
 
         if gravity is not None:


### PR DESCRIPTION
This PR lets the McStasScript `instr.settings` code support `mpi=‘auto’` and in this special case simply forward this to `mcrun`.

(`mcrun` includes relevant platform-independent code to select max. parallelisation allowed by OS.)