### PR TITLE
Handling of mcrun return code

### DIFF
--- a/mcstasscript/helper/managed_mcrun.py
+++ b/mcstasscript/helper/managed_mcrun.py
@@ -302,9 +302,9 @@ class ManagedMcrun:
 
         if process.returncode != 0:
             print("Simulation signaled that it failed by non-zero return code")
-            print(highlight(process.stdout, "error", return_section=True,
-                            after_lines=5, highlight_type="FAIL"))
-        elif self.suppress_output is False:
+            print_sim_output(process.stdout)
+
+        if self.suppress_output is False and process.returncode == 0:
             print_sim_output(process.stdout)
 
         if os.path.isdir(self.data_folder_name):

--- a/mcstasscript/helper/managed_mcrun.py
+++ b/mcstasscript/helper/managed_mcrun.py
@@ -112,6 +112,9 @@ class ManagedMcrun:
         self.suppress_output = False
         self.component_data = None
         self.simulation_performed = False
+        self.simulation_wrote_data = False
+        self.simulation_succeeded = False
+
 
         # executable_path always in kwargs
         if "executable_path" in kwargs:
@@ -297,13 +300,22 @@ class ManagedMcrun:
                                  universal_newlines=True,
                                  cwd=self.run_path)
 
-        if self.suppress_output is False:
+        if process.returncode != 0:
+            print("Simulation signaled that it failed by non-zero return code")
+            print(highlight(process.stdout, "error", return_section=True,
+                            after_lines=5, highlight_type="FAIL"))
+        elif self.suppress_output is False:
             print_sim_output(process.stdout)
 
-        if not os.path.isdir(self.data_folder_name):
+        if os.path.isdir(self.data_folder_name):
+            self.simulation_wrote_data = True
+        else:
             warnings.warn("Simulation did not create data folder, most likely failed.")
 
-        self.simulation_performed = True
+        self.simulation_performed = True  # Signals simulation was executed
+
+        if process.returncode == 0 and self.simulation_wrote_data:
+            self.simulation_succeeded = True  # Signals simulation ran as expected
 
     def load_results(self, *args):
         """

--- a/mcstasscript/instrument_diagnostics/beam_diagnostics.py
+++ b/mcstasscript/instrument_diagnostics/beam_diagnostics.py
@@ -15,6 +15,7 @@ def sanitise_comp_name(comp_name):
 
     return comp_name
 
+
 class DiagnosticsPoint:
     def __init__(self, instr, comp_name, before=True, rays=50000):
         comp_name = sanitise_comp_name(comp_name)

--- a/mcstasscript/interface/instr.py
+++ b/mcstasscript/interface/instr.py
@@ -2567,10 +2567,33 @@ class McCode_instr(BaseCalculator):
         # Run the simulation and return data
         simulation.run_simulation()
 
-        # Load data and store in __data
-        #data = simulation.load_results()
-        #self._set_data(data)
-        
+        if simulation.simulation_succeeded:
+            # Good return code and data generated
+            return self.__handle_simulation_output(simulation)
+        elif simulation.simulation_wrote_data:
+            # Something went wrong, in some cases data can still be read
+            try:
+                #  Attempt to read the data
+                return self.__handle_simulation_output(simulation)
+            except:
+                # If data could not be read, acknowledge failure (run_simulation will print errors)
+                raise ValueError("Simulation failed and it was not possible to read results")
+        else:
+            raise ValueError("Simulation failed and no data was written to disk")
+
+    def __handle_simulation_output(self, simulation):
+        """
+        Reads simulation data, stores it according to libpyvinyl convention
+
+        Parameters
+        ----------
+        output_path : ManagedMcrun object
+                Simulation that has been executed
+        """
+
+        if not simulation.simulation_performed:
+            raise ValueError("Simulation was not executed.")
+
         ## look for MCPL_output components and the defined filenames
         self.__add_mcpl_to_output(simulation)
 
@@ -2579,7 +2602,7 @@ class McCode_instr(BaseCalculator):
         data_dict = {"data": data}
         # adding to the libpyvinyl output datacollection with key = sim_data_key
         sim_data_key = self.output_keys[0]
-        output_data = self.output[sim_data_key] 
+        output_data = self.output[sim_data_key]
         output_data.set_dict(data_dict)
 
         if self.run_to_ref is not None:

--- a/mcstasscript/tests/test_Instr.py
+++ b/mcstasscript/tests/test_Instr.py
@@ -15,8 +15,19 @@ from mcstasscript.tests.helpers_for_tests import WorkInTestDir
 from mcstasscript.helper.exceptions import McStasError
 from mcstasscript.helper.mcstas_objects import Component
 from mcstasscript.helper.beam_dump_database import BeamDump
+from mcstasscript.helper.managed_mcrun import ManagedMcrun
 
 run_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '.')
+
+
+real_isdir = os.path.isdir
+
+def mock_isdir(path):
+    if os.path.basename(path) == "folder_name_which_is_unused":
+        print("specific path mocked")
+        return True
+    print("mock_isdir called with ", path)
+    return real_isdir(path)
 
 class DummyComponent(Component):
     def __init__(self, *args, **kwargs):
@@ -2044,10 +2055,12 @@ class TestMcStas_instr(unittest.TestCase):
                                    + "test_run_backengine_basic")
 
             instr = setup_populated_x_ray_instr_with_dummy_path()
-            instr.run_full_instrument(output_path=new_folder_name,
-                                      increment_folder_name=False,
-                                      executable_path=executable_path,
-                                      parameters={"theta": 1})
+            with unittest.mock.patch("os.path.isdir", side_effect=mock_isdir):
+                with unittest.mock.patch.object(ManagedMcrun, "load_results", return_value=None):
+                    instr.run_full_instrument(output_path=new_folder_name,
+                                              increment_folder_name=False,
+                                              executable_path=executable_path,
+                                              parameters={"theta": 1})
 
         expected_path = os.path.join(executable_path, "mxrun")
         expected_path = '"' + expected_path + '"'
@@ -2089,6 +2102,8 @@ class TestMcStas_instr(unittest.TestCase):
             with self.assertRaises(NameError):
                 instr.backengine()
 
+
+
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     @unittest.mock.patch("subprocess.run")
     def test_run_backengine_basic(self, mock_sub, mock_stdout):
@@ -2116,7 +2131,9 @@ class TestMcStas_instr(unittest.TestCase):
             instr.settings(output_path=new_folder_name,
                            increment_folder_name=True,
                            executable_path=executable_path)
-            instr.backengine()
+            with unittest.mock.patch("os.path.isdir", side_effect=mock_isdir):
+                with unittest.mock.patch.object(ManagedMcrun, "load_results", return_value=None):
+                    instr.backengine()
 
         expected_path = os.path.join(executable_path, "mcrun")
         expected_path = '"' + expected_path + '"'
@@ -2167,7 +2184,9 @@ class TestMcStas_instr(unittest.TestCase):
                            seed=300, gravity=True, checks=False,
                            save_comp_pars=True)
             instr.show_settings()
-            instr.backengine()
+            with unittest.mock.patch("os.path.isdir", side_effect=mock_isdir):
+                with unittest.mock.patch.object(ManagedMcrun, "load_results", return_value=None):
+                    instr.backengine()
 
         expected_path = os.path.join(executable_path, "mcrun")
         expected_path = '"' + expected_path + '"'
@@ -2220,7 +2239,9 @@ class TestMcStas_instr(unittest.TestCase):
                            seed=300, gravity=True, checks=False,
                            save_comp_pars=True)
             instr.show_settings()
-            instr.backengine()
+            with unittest.mock.patch("os.path.isdir", side_effect=mock_isdir):
+                with unittest.mock.patch.object(ManagedMcrun, "load_results", return_value=None):
+                    instr.backengine()
 
         expected_path = os.path.join(executable_path, "mcrun")
         expected_path = '"' + expected_path + '"'
@@ -2268,17 +2289,19 @@ class TestMcStas_instr(unittest.TestCase):
             instr.add_parameter("A")
             instr.add_parameter("BC")
 
-            instr.run_full_instrument(output_path=new_folder_name,
-                                      increment_folder_name=False,
-                                      executable_path=executable_path,
-                                      mpi=7,
-                                      seed=300,
-                                      ncount=48.4,
-                                      gravity=True,
-                                      custom_flags="-fo",
-                                      parameters={"A": 2,
-                                                  "BC": "car",
-                                                  "theta": "\"toy\""})
+            with unittest.mock.patch("os.path.isdir", side_effect=mock_isdir):
+                with unittest.mock.patch.object(ManagedMcrun, "load_results", return_value=None):
+                    instr.run_full_instrument(output_path=new_folder_name,
+                                              increment_folder_name=False,
+                                              executable_path=executable_path,
+                                              mpi=7,
+                                              seed=300,
+                                              ncount=48.4,
+                                              gravity=True,
+                                              custom_flags="-fo",
+                                              parameters={"A": 2,
+                                                          "BC": "car",
+                                                          "theta": "\"toy\""})
 
         expected_path = os.path.join(executable_path, "mcrun")
         expected_path = '"' + expected_path + '"'
@@ -2321,16 +2344,18 @@ class TestMcStas_instr(unittest.TestCase):
             instr.add_parameter("A")
             instr.add_parameter("BC")
 
-            instr.run_full_instrument(output_path=new_folder_name,
-                                      increment_folder_name=False,
-                                      executable_path=executable_path,
-                                      mpi=7,
-                                      ncount=48.4,
-                                      custom_flags="-fo",
-                                      parameters={"A": 2,
-                                                  "BC": "car",
-                                                  "theta": "\"toy\"",
-                                                  "has_default": 10})
+            with unittest.mock.patch("os.path.isdir", side_effect=mock_isdir):
+                with unittest.mock.patch.object(ManagedMcrun, "load_results", return_value=None):
+                    instr.run_full_instrument(output_path=new_folder_name,
+                                              increment_folder_name=False,
+                                              executable_path=executable_path,
+                                              mpi=7,
+                                              ncount=48.4,
+                                              custom_flags="-fo",
+                                              parameters={"A": 2,
+                                                          "BC": "car",
+                                                          "theta": "\"toy\"",
+                                                          "has_default": 10})
 
         expected_path = os.path.join(executable_path, "mcrun")
         expected_path = '"' + expected_path + '"'
@@ -2371,10 +2396,12 @@ class TestMcStas_instr(unittest.TestCase):
 
             instr = setup_populated_x_ray_instr_with_dummy_path()
 
-            instr.run_full_instrument(output_path=new_folder_name,
-                                      increment_folder_name=False,
-                                      executable_path=executable_path,
-                                      parameters={"theta": 1})
+            with unittest.mock.patch("os.path.isdir", side_effect=mock_isdir):
+                with unittest.mock.patch.object(ManagedMcrun, "load_results", return_value=None):
+                    instr.run_full_instrument(output_path=new_folder_name,
+                                              increment_folder_name=False,
+                                              executable_path=executable_path,
+                                              parameters={"theta": 1})
 
         expected_path = os.path.join(executable_path, "mxrun")
         expected_path = '"' + expected_path + '"'


### PR DESCRIPTION
Added code that reads the return code of mcrun and acts accordingly.

If return code is 0 and folder generated, all runs as it always has.

If return code is not 0, parts of the stdout that contain the word error is printed even with suppress_output is used. If a data folder is written, an attempt is made at reading it.